### PR TITLE
[REG-68] add script to generate config file, automatic generation with …

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,16 +2,16 @@ version: 1
 
 update_configs:
 
-    - package_manager: "javascript"
-      directory: "/packages//"
-      update_schedule: "live"
-      default_reviewers:
-        - ArtemFrantsiian
-        - ni3gavhane
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    default_reviewers:
+      - ArtemFrantsiian
+      - ni3gavhane
 
-    - package_manager: "javascript"
-      directory: "/packages/core"
-      update_schedule: "live"
-      default_reviewers:
-        - ArtemFrantsiian
-        - ni3gavhane
+  - package_manager: "javascript"
+    directory: "/packages/core"
+    update_schedule: "live"
+    default_reviewers:
+      - ArtemFrantsiian
+      - ni3gavhane

--- a/.dependabot/index.js
+++ b/.dependabot/index.js
@@ -25,8 +25,8 @@ function configDependabot() {
 
     stream.write(config);
 
-    directories.forEach(function(directory) {
-        const path = `/packages/${directory}`;
+    directories.forEach((directory, index) => {
+        const path = index ? `/packages/${directory}` : directory;
         stream.write(packageTemplate(path));
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const source = require('vinyl-source-stream');
 const buffer = require('vinyl-buffer');
 const tsify = require('tsify');
 const lernaJSON = require('./lerna.json');
-const dependabot = require('./.dependabot');
+const configDependabot = require('./.dependabot');
 
 const DEST = path.join(__dirname, 'build/');
 
@@ -39,7 +39,7 @@ function clean(done) {
 }
 
 function generateDependabotConfig(done) {
-  dependabot();
+  configDependabot();
   done();
 }
 


### PR DESCRIPTION
### Summary
|             |   |
|-------------|---|
| Description |   Fix Dependabot Config|
| Jira issue  |   https://energyweb.atlassian.net/browse/REG-68|

### Steps to reproduce
- One should run 'gulp dependabot' and the configuration file will be automatically generated/updated

### Previous behavior
Configuration file was not written correctly, as pattern matching of specified path to files is not supported in YAML

### Actual behavior
Simple script implemented to automatically generate a Dependabot configuration file, depending on the subfolders of 'packages' directory. Gulp method added to execute the script.