### PR TITLE
feature/REG-230-JWT-FEATURES-REUSE

### DIFF
--- a/packages/claims/src/claimsUser/claimsUser.ts
+++ b/packages/claims/src/claimsUser/claimsUser.ts
@@ -47,13 +47,20 @@ export class ClaimsUser extends Claims implements IClaimsUser {
    *
    * @returns { Promise<string> }
    */
-  async createPublicClaim(publicData: object): Promise<string> {
+  async createPublicClaim(publicData: object, jwtOptions: any = {}): Promise<string> {
+    jwtOptions.subject = jwtOptions.subject || this.did;
+    jwtOptions.issuer = this.did;
     const claim: IPublicClaim = {
-      did: this.did,
+      did: jwtOptions.subject,
       signer: this.did,
       claimData: publicData,
     };
-    return this.jwt.sign(claim, { algorithm: 'ES256', noTimestamp: true });
+    return this.jwt.sign(
+      claim,
+      {
+        ...jwtOptions, algorithm: 'ES256',
+      },
+    );
   }
 
   /**
@@ -81,7 +88,10 @@ export class ClaimsUser extends Claims implements IClaimsUser {
   async createPrivateClaim(
     privateData: { [key: string]: string },
     issuer: string,
+    jwtOptions: any = {},
   ): Promise<{ token: string; saltedFields: ISaltedFields }> {
+    jwtOptions.subject = jwtOptions.subject || this.did;
+    jwtOptions.issuer = this.did;
     const saltedFields: { [key: string]: string } = {};
     const claim: IPrivateClaim = {
       did: this.did,
@@ -100,7 +110,9 @@ export class ClaimsUser extends Claims implements IClaimsUser {
       claim.claimData[key] = encryptedValue.toString('hex');
       saltedFields[key] = saltedValue;
     });
-    const token = await this.jwt.sign(claim, { algorithm: 'ES256', noTimestamp: true });
+    const token = await this.jwt.sign(claim, {
+      ...jwtOptions, algorithm: 'ES256',
+    });
     return { token, saltedFields };
   }
 
@@ -126,7 +138,13 @@ export class ClaimsUser extends Claims implements IClaimsUser {
    *
    * @returns { Promise<string> }
    */
-  async createProofClaim(claimUrl: string, proofData: IProofData): Promise<string> {
+  async createProofClaim(
+    claimUrl: string,
+    proofData: IProofData,
+    jwtOptions: any = {},
+  ): Promise<string> {
+    jwtOptions.subject = jwtOptions.subject || this.did;
+    jwtOptions.issuer = this.did;
     const claim: IProofClaim = {
       did: this.did,
       signer: this.did,
@@ -158,7 +176,9 @@ export class ClaimsUser extends Claims implements IClaimsUser {
         };
       }
     });
-    return this.jwt.sign(claim, { algorithm: 'ES256', noTimestamp: true });
+    return this.jwt.sign(claim, {
+      ...jwtOptions, algorithm: 'ES256',
+    });
   }
 
   /**

--- a/packages/claims/test/claimsUser.test.ts
+++ b/packages/claims/test/claimsUser.test.ts
@@ -53,7 +53,7 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
     };
     const token = await userClaims.createPublicClaim(publicData);
     const claim = await userClaims.jwt.verify(token, userClaims.keys.publicKey, { algorithm: 'ES256', noTimestamp: true });
-    claim.should.deep.equal({
+    claim.should.deep.include({
       did: userDdid,
       signer: userDdid,
       claimData: publicData,


### PR DESCRIPTION
### Summary
|             |   |
|-------------|---|
| Description | Use standard JWT options instead of custom ones |
| Jira issue  | https://energyweb.atlassian.net/browse/REG-195 |

#### Type of request
<!--- Please delete options that are not relevant. -->
### List of Features
- All claim creation methods have optional argument jwtOptions in which you can pass all options provided by jwt standard;
- Default claim subject is set to claim issuer;
- All existing functionality used in FlexHub and FlexHub UI projects is kept