### PR TITLE
Add support of WalletConnect in claims

### DIFF
--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -37,7 +37,7 @@ export class Claims implements IClaims {
   ) {
     const keys = signMethod as IKeys;
     const signer = signMethod as Signer;
-    if (keys.privateKey && keys.publicKey) {
+    if (Object.prototype.hasOwnProperty.call(signMethod, 'privateKey')) {
       this.keys = {
         privateKey: keys.privateKey,
         publicKey: Promise.resolve(keys.publicKey),

--- a/packages/claims/src/claimsIssuer/claimsIssuer.ts
+++ b/packages/claims/src/claimsIssuer/claimsIssuer.ts
@@ -55,6 +55,9 @@ export class ClaimsIssuer extends Claims implements IClaimsIssuer {
    * @returns { Promise<string> } issued token
    */
   async issuePrivateClaim(token: string): Promise<string> {
+    if (!this.keys.privateKey) {
+      throw new Error('Private claim not supported');
+    }
     const curve: sjcl.SjclEllipticalCurve = sjcl.ecc.curves.k256;
     const g = curve.G;
     const claim: IPrivateClaim = this.jwt.decode(token) as IPrivateClaim;

--- a/packages/claims/src/models/index.ts
+++ b/packages/claims/src/models/index.ts
@@ -36,7 +36,10 @@ export interface IProofData {
 
 export interface IClaims {
   did: string;
-  keys: IKeys;
+  keys: {
+    privateKey: string;
+    publicKey: Promise<string>;
+  };
   jwt: IJWT;
   verify(
     claimUrl: string, hashFns?: { [hashAlg: string]: (data: string) => string },

--- a/packages/claims/test/claimsUser.test.ts
+++ b/packages/claims/test/claimsUser.test.ts
@@ -48,7 +48,7 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
     const token = await userClaims.createPublicClaim(publicData);
     (await userClaims.verifyPublicClaim(token, publicData)).should.be.true;
     const claim = await userClaims.jwt.verify(
-      token, userClaims.keys.publicKey, { noTimestamp: true },
+      token, await userClaims.keys.publicKey, { noTimestamp: true },
     );
     claim.should.deep.include({
       did: userDdid,
@@ -86,7 +86,7 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
     const claimUrl = 'http://test.com';
     const proofData = { secret: { value: '123abc', encrypted: true } };
     const token = await userClaims.createProofClaim(claimUrl, proofData);
-    const claim = await userClaims.jwt.verify(token, userClaims.keys.publicKey, { noTimestamp: true }) as IProofClaim;
+    const claim = await userClaims.jwt.verify(token, await userClaims.keys.publicKey, { noTimestamp: true }) as IProofClaim;
     claim.should.include({ did: userDdid, signer: userDdid, claimUrl });
     claim.should.have.nested.property('proofData.secret.value.h').which.instanceOf(Array);
     claim.should.have.nested.property('proofData.secret.value.s').which.instanceOf(Array);

--- a/packages/jwt/src/index.ts
+++ b/packages/jwt/src/index.ts
@@ -5,7 +5,9 @@ import { Signer } from 'ethers';
 import { IKeys } from '@ew-did-registry/keys';
 import { PromiseRejection, PromiseResolution } from 'promise.allsettled';
 import { IJWT } from './interface';
-import { createSignWithEthersSigner, createSignWithKeys } from './sign';
+import {
+  createSignWithEthersSigner, createSignWithKeys, JwtOptions, JwtPayload,
+} from './sign';
 import { verificationMethods } from './verify';
 
 class JWT implements IJWT {
@@ -34,8 +36,8 @@ class JWT implements IJWT {
    * @returns {Promise<string>}
    */
   public sign: (
-    payload: string | { [key: string]: string | object },
-    options?: object) => Promise<string>;
+    payload: string | JwtPayload,
+    options?: JwtOptions) => Promise<string>;
 
   /**
    * Key pair has to be passed on construction to JWT

--- a/packages/jwt/src/interface.ts
+++ b/packages/jwt/src/interface.ts
@@ -1,33 +1,35 @@
+import { JwtPayload, JwtOptions } from './sign';
+
 /**
  * The JWT exposes methods to create/sign, verify, and decode JSON web tokens
  */
 export interface IJWT {
-    /**
-     * Method accepts claim payload and options, and returns a string Promise
-     * @param {object} payload
-     * @param {object} options
-     * @returns {Promise<string>}
-     */
-    sign(payload: string | { [key: string]: string | object}, options?: object): Promise<string>;
+  /**
+   * Method accepts claim payload and options, and returns a string Promise
+   * @param {object} payload
+   * @param {object} options
+   * @returns {Promise<string>}
+   */
+  sign(payload: string | JwtPayload, options?: JwtOptions): Promise<string>;
 
-    /**
-     * Method accepts the token, publicKey of signing entity, as well as options
-     * Decoded JWT is returned in the Promise, if the signature is correct, otherwise
-     * an error will be thrown
-     * @param {string} token
-     * @param {string} publicKey
-     * @param {object} options
-     * @returns {Promise<object>}
-     */
-    verify(token: string, publicKey: string, options?: object): Promise<object>;
+  /**
+   * Method accepts the token, publicKey of signing entity, as well as options
+   * Decoded JWT is returned in the Promise, if the signature is correct, otherwise
+   * an error will be thrown
+   * @param {string} token
+   * @param {string} publicKey
+   * @param {object} options
+   * @returns {Promise<object>}
+   */
+  verify(token: string, publicKey: string, options?: object): Promise<object>;
 
-    /**
-     * Method decodes JWT without checking the signature. This can be useful in cases,
-     * where Public Key of the signer is yet to be retrieved using claim data stored in JWT.
-     * Decoded JSON web token is returned.
-     * @param {string} token
-     * @param {object} options
-     * @returns {object}
-     */
-    decode(token: string, options?: object): string | { [key: string]: string | object };
+  /**
+   * Method decodes JWT without checking the signature. This can be useful in cases,
+   * where Public Key of the signer is yet to be retrieved using claim data stored in JWT.
+   * Decoded JSON web token is returned.
+   * @param {string} token
+   * @param {object} options
+   * @returns {object}
+   */
+  decode(token: string, options?: object): string | { [key: string]: string | object };
 }


### PR DESCRIPTION
### Summary
|             |   |
|-------------|---|
| Description | Enables of using ethers.Signer in claims |
| Jira issue  | https://energyweb.atlassian.net/browse/MYEN-115 |

### List of Features
- [x] Claims are constructed depending on signer method - IKeys or Signer
- [ ] claim.keys.publicKey is now Promise<string> instead of string, because Signer.getAddress() used for calculation of public key is asynchronos
- [ ] JWT constructed with Signer accepts standard jwt options - issuer and subject 