### PR TITLE
feature/resolver fetch events from specific block

### DIFF
--- a/packages/did-document/src/full/documentFull.ts
+++ b/packages/did-document/src/full/documentFull.ts
@@ -1,6 +1,7 @@
 import {
   DIDAttribute, IOperator, IUpdateData, PubKeyType,
 } from '@ew-did-registry/did-resolver-interface';
+import { utils } from 'ethers';
 import { IDIDDocumentFull } from './interface';
 import { DIDDocumentLite } from '../lite';
 
@@ -42,8 +43,8 @@ class DIDDocumentFull extends DIDDocumentLite implements IDIDDocumentFull {
    * ```
    * @return { boolean }
    */
-  async deactivate(): Promise<boolean> {
-    return this._operator.deactivate(this.did);
+  async deactivate(): Promise<void> {
+    await this._operator.deactivate(this.did);
   }
 
   /**
@@ -77,7 +78,7 @@ class DIDDocumentFull extends DIDDocumentLite implements IDIDDocumentFull {
     attribute: DIDAttribute,
     data: IUpdateData,
     validity?: number,
-  ): Promise<boolean> {
+  ): Promise<utils.BigNumber> {
     return this._operator.update(this.did, attribute, data, validity);
   }
 

--- a/packages/did-document/src/full/interface.ts
+++ b/packages/did-document/src/full/interface.ts
@@ -1,5 +1,6 @@
 import { DIDAttribute, IUpdateData, PubKeyType } from '@ew-did-registry/did-resolver-interface';
 import { BigNumber } from 'ethers/utils';
+import { utils } from 'ethers';
 import { IDIDDocumentLite } from '../lite';
 
 /**
@@ -22,13 +23,13 @@ export interface IDIDDocumentFull extends IDIDDocumentLite {
    */
   update(
     attribute: DIDAttribute, data: IUpdateData, validity?: number | BigNumber
-  ): Promise<boolean>;
+  ): Promise<utils.BigNumber>;
 
   /**
    * On success the status of the DID Document is changed from “active” to “deactivated”.
    * @returns {boolean}
    */
-  deactivate(): Promise<boolean>;
+  deactivate(): Promise<void>;
 
   revokeDelegate(delegateType: PubKeyType, delegateDID: string): Promise<boolean>;
 

--- a/packages/did-document/test/did-document-full.test.ts
+++ b/packages/did-document/test/did-document-full.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax */
-import chai, { expect } from 'chai';
+import chai, { expect, should } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {
   Operator, signerFromKeys, getProvider,
@@ -20,8 +20,8 @@ import DIDDocumentFull from '../src/full/documentFull';
 import { deployRegistry } from '../../../tests/init-ganache';
 import { IDIDDocumentFull } from '../src/full/interface';
 
+should();
 chai.use(chaiAsPromised);
-chai.should();
 
 describe('[DID DOCUMENT FULL PACKAGE]', function () {
   this.timeout(0);
@@ -60,15 +60,12 @@ describe('[DID DOCUMENT FULL PACKAGE]', function () {
       },
       validity,
     );
-    expect(updated).to.be.true;
+    expect(updated.toNumber()).to.be.an('number');
   });
 
-  it('deactivate document should return true', async () => {
-    const deactivated = await fullDoc.deactivate();
-    expect(deactivated).to.be.true;
-  });
+  it('document can be deactivated', async () => fullDoc.deactivate().should.be.fulfilled);
 
-  it('revokeDelegate makes removes authentication method and corresponding public key', async () => {
+  it('revokeDelegate removes authentication method and corresponding public key', async () => {
     const attribute = DIDAttribute.Authenticate;
     const keysDelegate = new Keys();
     const delegate = new Wallet(keysDelegate.privateKey);
@@ -78,8 +75,7 @@ describe('[DID DOCUMENT FULL PACKAGE]', function () {
       encoding: Encoding.HEX,
       delegate: delegate.address,
     };
-    const updated = await fullDoc.update(attribute, updateData, validity);
-    expect(updated).to.be.true;
+    await fullDoc.update(attribute, updateData, validity);
     let document = await operator.read(did);
     expect(document.id).equal(did);
     let authMethod = document.publicKey.find(

--- a/packages/did-ethr-resolver/src/functions/functions.ts
+++ b/packages/did-ethr-resolver/src/functions/functions.ts
@@ -295,7 +295,7 @@ export const fetchDataFromEvents = async (
   const { address } = registrySettings;
   while (
     nextBlock.toNumber() !== 0
-    && nextBlock.toNumber() > document.topBlock.toNumber()
+    && nextBlock.toNumber() >= document.topBlock.toNumber()
   ) {
     // eslint-disable-next-line no-await-in-loop
     nextBlock = await getEventsFromBlock(

--- a/packages/did-ethr-resolver/src/implementations/proxyOperator.ts
+++ b/packages/did-ethr-resolver/src/implementations/proxyOperator.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-await-in-loop,no-restricted-syntax */
-import { Contract, ethers } from 'ethers';
+import {
+  Contract, Event, ethers, utils,
+} from 'ethers';
 import Web3 from 'web3';
 import {
   DIDAttribute,
@@ -11,6 +13,7 @@ import {
   IdentityOwner,
 } from '@ew-did-registry/did-resolver-interface';
 import proxyBuild from '@ew-did-registry/proxyidentity/build/contracts/ProxyIdentity.json';
+import { BigNumber } from 'ethers/utils';
 import {
   ethrReg,
 } from '../constants';
@@ -20,6 +23,8 @@ const { PublicKey, ServicePoint } = DIDAttribute;
 
 export class ProxyOperator extends Operator {
   private proxy: Contract;
+
+  private registry: Contract;
 
   private web3: Web3;
 
@@ -32,6 +37,7 @@ export class ProxyOperator extends Operator {
   constructor(owner: IdentityOwner, settings: RegistrySettings, proxy: string) {
     super(owner, settings);
     this.proxy = new Contract(proxy, proxyBuild.abi, owner);
+    this.registry = new Contract(this.settings.address, this.settings.abi, owner);
     this.web3 = new Web3();
   }
 
@@ -51,16 +57,19 @@ export class ProxyOperator extends Operator {
    * @param { string } did
    * @returns Promise<boolean>
    */
-  async deactivate(did: string): Promise<boolean> {
+  async deactivate(did: string): Promise<void> {
     const document = await this.read(did);
-    const authRevoked = await this._revokeAuthentications(
-      did,
-      document.authentication as IAuthentication[],
-      document.publicKey as IPublicKey[],
-    );
-    const pubKeysRevoked = await this._revokePublicKeys(did, document.publicKey);
-    const endpointsRevoked = await this._revokeServices(did, document.service);
-    return authRevoked && pubKeysRevoked && endpointsRevoked;
+    try {
+      await this._revokeAuthentications(
+        did,
+        document.authentication as IAuthentication[],
+        document.publicKey as IPublicKey[],
+      );
+      await this._revokePublicKeys(did, document.publicKey);
+      await this._revokeServices(did, document.service);
+    } catch (e) {
+      throw new Error(`Can't deactivate document: ${e.message}`);
+    }
   }
 
   /**
@@ -170,7 +179,7 @@ export class ProxyOperator extends Operator {
     overrides?: {
       nonce?: number;
     },
-  ): Promise<boolean> {
+  ): Promise<utils.BigNumber> {
     const identity = this._parseDid(did);
     const attributeName = this._composeAttributeName(didAttribute, updateData);
     const bytesOfAttribute = ethers.utils.formatBytes32String(attributeName);
@@ -187,15 +196,16 @@ export class ProxyOperator extends Operator {
     } else {
       methodName = 'addDelegate';
     }
+    const methodAbi: any = ethrReg.abi.find((f) => f.name === methodName);
+    const data: string = this.web3.eth.abi.encodeFunctionCall(methodAbi, params);
+    let event: Event;
     try {
-      const methodAbi: any = ethrReg.abi.find((f) => f.name === methodName);
-      const data: string = this.web3.eth.abi.encodeFunctionCall(methodAbi, params);
-      await this.proxy
-        .sendTransaction(data, this.settings.address, 0)
-        .then((tx: any) => tx.wait());
-    } catch (error) {
-      throw new Error(error.message);
+      const tx = await this.proxy.sendTransaction(data, this.settings.address, 0);
+      const receipt = await tx.wait();
+      event = receipt.events.find((e: Event) => e.event === 'TransactionSent');
+      return new BigNumber(event.blockNumber);
+    } catch (e) {
+      throw new Error(`Can't send transaction: ${e.message}`);
     }
-    return true;
   }
 }

--- a/packages/did-ethr-resolver/src/implementations/resolver.ts
+++ b/packages/did-ethr-resolver/src/implementations/resolver.ts
@@ -17,8 +17,6 @@ import { Methods } from '@ew-did-registry/did';
 import { DIDPattern, ethrReg } from '../constants';
 import { fetchDataFromEvents, wrapDidDocument, query } from '../functions';
 
-const { BigNumber } = utils;
-
 /**
  * To support different methods compliant with ERC1056, the user/developer simply has to provide
  * different resolver settings. The default resolver settings are provided in the 'constants' folder

--- a/packages/did-ethr-resolver/src/implementations/resolver.ts
+++ b/packages/did-ethr-resolver/src/implementations/resolver.ts
@@ -17,6 +17,8 @@ import { Methods } from '@ew-did-registry/did';
 import { DIDPattern, ethrReg } from '../constants';
 import { fetchDataFromEvents, wrapDidDocument, query } from '../functions';
 
+const { BigNumber } = utils;
+
 /**
  * To support different methods compliant with ERC1056, the user/developer simply has to provide
  * different resolver settings. The default resolver settings are provided in the 'constants' folder
@@ -84,7 +86,7 @@ class Resolver implements IResolver {
       throw new Error('Invalid did provided');
     }
 
-    if (this._document === undefined || this._document.owner !== did) {
+    if (this._document === undefined || this._document.owner !== address) {
       this._document = {
         owner: address,
         topBlock: new utils.BigNumber(0),
@@ -178,6 +180,29 @@ class Resolver implements IResolver {
         publicKey: { id: `${did}#${KeyTags.OWNER}` },
       },
     ) as IPublicKey)?.publicKeyHex.slice(2);
+  }
+
+  async readFromBlock(
+    did: string,
+    topBlock: utils.BigNumber,
+  ): Promise<IDIDDocument> {
+    const [, , address] = did.split(':');
+    if (this._document === undefined || this._document.owner !== address) {
+      this._document = {
+        owner: address,
+        topBlock,
+        authentication: {},
+        publicKey: {},
+        service: {},
+        attributes: new Map(),
+      };
+    }
+    return this.read(did);
+  }
+
+  async lastBlock(did: string): Promise<utils.BigNumber> {
+    const [, , address] = did.split(':');
+    return this._contract.changed(address);
   }
 }
 

--- a/packages/did-ethr-resolver/test/did-proxy-operator.test.ts
+++ b/packages/did-ethr-resolver/test/did-proxy-operator.test.ts
@@ -14,7 +14,7 @@ import {
 import { JsonRpcProvider } from 'ethers/providers';
 import { proxyBuild, multiproxyBuild } from '@ew-did-registry/proxyidentity';
 import {
-  ethrReg, ProxyOperator, signerFromKeys, getProvider, walletPubKey, withProvider, withKey,
+  ethrReg, ProxyOperator, signerFromKeys, walletPubKey, withProvider, withKey,
 } from '../src';
 import { deployRegistry } from '../../../tests/init-ganache';
 
@@ -102,8 +102,7 @@ describe('[DID-PROXY-OPERATOR]', function () {
         encoding: HEX,
         delegate: delegate.address,
       };
-      const updated = await operator.update(did, attribute, updateData, validity);
-      expect(updated).to.be.true;
+      await operator.update(did, attribute, updateData, validity);
       const document = await operator.read(did);
       expect(document.id).equal(did);
       const authMethod = document.publicKey.find(
@@ -126,8 +125,7 @@ describe('[DID-PROXY-OPERATOR]', function () {
       encoding: HEX,
       delegate: delegate.address,
     };
-    const updated = await operator.update(did, attribute, updateData, validity);
-    expect(updated).to.be.true;
+    await operator.update(did, attribute, updateData, validity);
     const document = await operator.read(did);
     expect(document.id).equal(did);
     const publicKeyId = `${did}#delegate-${updateData.type}-${updateData.delegate}`;
@@ -157,8 +155,7 @@ describe('[DID-PROXY-OPERATOR]', function () {
         serviceEndpoint: endpoint,
       },
     };
-    const updated = await operator.update(did, attribute, updateData, validity);
-    expect(updated).to.be.true;
+    await operator.update(did, attribute, updateData, validity);
     const document = await operator.read(did);
     expect(document.id).equal(did);
     expect(document.service.find(
@@ -238,8 +235,7 @@ describe('[DID-PROXY-OPERATOR]', function () {
     document = await operator.read(did);
     await operator.update(did, attribute, updateData, validity);
     document = await operator.read(did);
-    const result = await operator.deactivate(did);
-    expect(result).to.be.true;
+    await operator.deactivate(did);
     document = await operator.read(did);
     expect(document.service).to.be.empty;
     expect(document.publicKey).to.be.empty;
@@ -256,8 +252,7 @@ describe('[DID-PROXY-OPERATOR]', function () {
       encoding: HEX,
       delegate: delegate.address,
     };
-    const updated = await operator.update(did, attribute, updateData, validity);
-    expect(updated).to.be.true;
+    await operator.update(did, attribute, updateData, validity);
     let document = await operator.read(did);
     expect(document.id).equal(did);
     let authMethod = document.publicKey.find(

--- a/packages/did-resolver-interface/src/interface.ts
+++ b/packages/did-resolver-interface/src/interface.ts
@@ -11,8 +11,6 @@ import {
   DocumentSelector,
 } from './models';
 
-const { BigNumber } = utils;
-
 export interface IResolver {
   /**
    * Constructor takes keys and resolver settings to create a new Resolver

--- a/packages/did-resolver-interface/src/interface.ts
+++ b/packages/did-resolver-interface/src/interface.ts
@@ -1,7 +1,17 @@
 import { utils } from 'ethers';
 import {
-  IDIDDocument, DIDAttribute, IUpdateData, DelegateTypes, IPublicKey, IServiceEndpoint, IAuthentication, PubKeyType, DocumentSelector,
+  IDIDDocument,
+  DIDAttribute,
+  IUpdateData,
+  DelegateTypes,
+  IPublicKey,
+  IServiceEndpoint,
+  IAuthentication,
+  PubKeyType,
+  DocumentSelector,
 } from './models';
+
+const { BigNumber } = utils;
 
 export interface IResolver {
   /**
@@ -53,6 +63,19 @@ export interface IResolver {
   ): Promise<IPublicKey | IServiceEndpoint | IAuthentication>;
 
   readOwnerPubKey(did: string): Promise<string>;
+
+  /**
+   * Reads events starting from specified block
+   *
+   * @param block {number} - block to start reading from
+   *
+   * @returns - part of document along with last read block
+   */
+  readFromBlock(did: string,
+    topBlock: utils.BigNumber,
+  ): Promise<IDIDDocument>;
+
+  lastBlock(did: string): Promise<utils.BigNumber>;
 }
 
 export interface IOperator extends IResolver {
@@ -79,7 +102,7 @@ export interface IOperator extends IResolver {
     attribute: DIDAttribute,
     value: IUpdateData,
     validity?: number | utils.BigNumber
-  ): Promise<boolean>;
+  ): Promise<utils.BigNumber>;
 
   /**
    * Attempts to deactivate the DID Document for a given DID.
@@ -89,7 +112,7 @@ export interface IOperator extends IResolver {
    * @param {string} did
    * @returns {boolean}
    */
-  deactivate(did: string): Promise<boolean>;
+  deactivate(did: string): Promise<void>;
 
   revokeDelegate(did: string, delegateType: PubKeyType, delegateDID: string): Promise<boolean>;
 


### PR DESCRIPTION
### Summary
|             |   |
|-------------|---|
| Description | Provide API to retrieve events starting from specified block |
| Jira issue  | https://energyweb.atlassian.net/browse/MYEN-349 |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

### List of Features
- added `Resolver.readFromBlock(did, block)` method
- `Operator.update` will return block number to use in conjunction with `Resolver.readFromBlock`
- `Operator.deactivate` will throw instead of returning false in case of failure