### PR TITLE
feature/separate documentFromBlock from Resolver

### DIFF
--- a/packages/did-document/src/lite/index.ts
+++ b/packages/did-document/src/lite/index.ts
@@ -9,6 +9,8 @@ import {
   DocumentSelector,
   IDIDLogData,
 } from '@ew-did-registry/did-resolver-interface';
+import { documentFromLogs } from '@ew-did-registry/did-ethr-resolver';
+
 import { IDIDDocumentLite } from './interface';
 
 class DIDDocumentLite implements IDIDDocumentLite {
@@ -82,8 +84,8 @@ class DIDDocumentLite implements IDIDDocumentLite {
     return this.resolver.readFromBlock(did, from);
   }
 
-  documentFromLogs(did: string, logs: IDIDLogData[]): IDIDDocument {
-    return this.resolver.documentFromLogs(did, logs);
+  fromLogs(logs: IDIDLogData[], did = this.did): IDIDDocument {
+    return documentFromLogs(did, logs);
   }
 }
 

--- a/packages/did-document/src/lite/interface.ts
+++ b/packages/did-document/src/lite/interface.ts
@@ -67,14 +67,14 @@ export interface IDIDDocumentLite {
    *
    * @param {string} did
    */
-  ownerPubKey(did: string): Promise<string>;
+  ownerPubKey(did?: string): Promise<string>;
 
-  lastBlock(did: string): Promise<utils.BigNumber>;
+  lastBlock(did?: string): Promise<utils.BigNumber>;
 
   readFromBlock(
     did: string,
     from: utils.BigNumber,
   ): Promise<IDIDLogData>;
 
-  documentFromLogs(did: string, logs: IDIDLogData[]): IDIDDocument;
+  fromLogs(logs: IDIDLogData[], did?: string): IDIDDocument;
 }

--- a/packages/did-document/test/did-document-full.test.ts
+++ b/packages/did-document/test/did-document-full.test.ts
@@ -214,7 +214,7 @@ describe('[DID DOCUMENT FULL PACKAGE]', function () {
       await fullDoc.readFromBlock(did, from),
     ];
 
-    expect(fullDoc.documentFromLogs(did, logs)).to.deep.equalInAnyOrder(await fullDoc.read(did));
+    expect(fullDoc.fromLogs(logs)).to.deep.equalInAnyOrder(await fullDoc.read(did));
   });
 
   it('attribute invalidated in new block should be excluded from document', async () => {
@@ -229,14 +229,14 @@ describe('[DID DOCUMENT FULL PACKAGE]', function () {
     await fullDoc.update(DIDAttribute.PublicKey, updateData, validity);
 
     const logsUpToFirstUpdate = await fullDoc.readFromBlock(did, new BigNumber(0));
-    const initialDoc = fullDoc.documentFromLogs(did, [logsUpToFirstUpdate]);
+    const initialDoc = fullDoc.fromLogs([logsUpToFirstUpdate]);
 
     expect(initialDoc.publicKey.find(({ id }) => id === keyId)).not.undefined;
 
     updateData.value = { publicKey: `0x${new Keys().publicKey}`, tag: 'key-0' };
     const from = await fullDoc.update(DIDAttribute.PublicKey, updateData, 0);
 
-    const updatedDoc = fullDoc.documentFromLogs(did, [
+    const updatedDoc = fullDoc.fromLogs([
       logsUpToFirstUpdate,
       await fullDoc.readFromBlock(did, from),
     ]);

--- a/packages/did-ethr-resolver/src/functions/functions.ts
+++ b/packages/did-ethr-resolver/src/functions/functions.ts
@@ -385,18 +385,26 @@ export const wrapDidDocument = (
   return didDocument;
 };
 
-export const mergeLogs = (logs: IDIDLogData[]): IDIDLogData => logs.reduce(
-  (doc, log) => {
-    doc.service = { ...doc.service, ...log.service };
+/**
+ * Restore document from partially read logs
+ *
+ * @param logs {IDIDLogData[]}
+ */
+export const mergeLogs = (logs: IDIDLogData[]): IDIDLogData => {
+  logs = logs.sort((a, b) => a.topBlock.sub(b.topBlock).toNumber());
+  return logs.reduce(
+    (doc, log) => {
+      doc.service = { ...doc.service, ...log.service };
 
-    doc.publicKey = { ...doc.publicKey, ...log.publicKey };
+      doc.publicKey = { ...doc.publicKey, ...log.publicKey };
 
-    doc.authentication = { ...doc.authentication, ...log.authentication };
+      doc.authentication = { ...doc.authentication, ...log.authentication };
 
-    return doc;
-  },
-  logs[0],
-);
+      return doc;
+    },
+    logs[0],
+  );
+};
 
 export const documentFromLogs = (did: string, logs: IDIDLogData[]): IDIDDocument => {
   const mergedLogs: IDIDLogData = mergeLogs(logs);

--- a/packages/did-ethr-resolver/src/functions/functions.ts
+++ b/packages/did-ethr-resolver/src/functions/functions.ts
@@ -384,3 +384,22 @@ export const wrapDidDocument = (
 
   return didDocument;
 };
+
+export const mergeLogs = (logs: IDIDLogData[]): IDIDLogData => logs.reduce(
+  (doc, log) => {
+    doc.service = { ...doc.service, ...log.service };
+
+    doc.publicKey = { ...doc.publicKey, ...log.publicKey };
+
+    doc.authentication = { ...doc.authentication, ...log.authentication };
+
+    return doc;
+  },
+  logs[0],
+);
+
+export const documentFromLogs = (did: string, logs: IDIDLogData[]): IDIDDocument => {
+  const mergedLogs: IDIDLogData = mergeLogs(logs);
+
+  return wrapDidDocument(did, mergedLogs);
+};

--- a/packages/did-ethr-resolver/src/implementations/resolver.ts
+++ b/packages/did-ethr-resolver/src/implementations/resolver.ts
@@ -199,27 +199,6 @@ class Resolver implements IResolver {
     return { ...this._document };
   }
 
-  documentFromLogs(did: string, logs: IDIDLogData[]): IDIDDocument {
-    const mergedLogs: IDIDLogData = this.mergeLogs(logs);
-
-    return wrapDidDocument(did, mergedLogs);
-  }
-
-  mergeLogs(logs: IDIDLogData[]): IDIDLogData {
-    return logs.reduce(
-      (doc, log) => {
-        doc.service = { ...doc.service, ...log.service };
-
-        doc.publicKey = { ...doc.publicKey, ...log.publicKey };
-
-        doc.authentication = { ...doc.authentication, ...log.authentication };
-
-        return doc;
-      },
-      logs[0],
-    );
-  }
-
   async lastBlock(did: string): Promise<utils.BigNumber> {
     const [, , address] = did.split(':');
     return this._contract.changed(address);

--- a/packages/did-ethr-resolver/src/index.ts
+++ b/packages/did-ethr-resolver/src/index.ts
@@ -1,3 +1,4 @@
 export * from './implementations';
 export * from './constants';
 export * from './utils';
+export * from './functions';

--- a/packages/did-resolver-interface/src/interface.ts
+++ b/packages/did-resolver-interface/src/interface.ts
@@ -74,8 +74,6 @@ export interface IResolver {
     topBlock: utils.BigNumber,
   ): Promise<IDIDLogData>;
 
-  documentFromLogs(did: string, logs: IDIDLogData[]): IDIDDocument;
-
   lastBlock(did: string): Promise<utils.BigNumber>;
 }
 


### PR DESCRIPTION
### Summary
|             |   |
|-------------|---|
| Description | Extract `documentFromBlock` and `mergeLogs` as separate functions. It will allow them to be used without Resolver been instantiated |
| Jira issue  | https://energyweb.atlassian.net/browse/MYEN-359 |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] New feature

### List of Features
- `documentFromBloc` and `mergeLogs` are exported globally from ethr-resolver
- `DIDDocumentLite.documentFromLogs` renamed to `DIDDocumentLite.fromLogs`
- `did` argument in `DIDDocumentLite` will have default value