### PR TITLE
test and initial fix for undefined serviceEndpoint ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,9 +127,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.10.tgz",
-      "integrity": "sha512-YV7r2YxdTUaw84EwNkyrRke/TJHR/UXGiyvACRqvdVJ2/syV2rQuJNnaRLSuYiop8cMRXOgseTGoJCWX0q2fFg==",
+      "version": "7.13.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+      "integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
       "requires": {
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-member-expression-to-functions": "^7.13.0",
@@ -4934,9 +4934,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
-      "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
+      "version": "7.1.13",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.13.tgz",
+      "integrity": "sha512-CC6amBNND16pTk4K3ZqKIaba6VGKAQs3gMjEY17FVd56oI/ZWt9OhS6riYiWv9s8ENbYUi7p8lgqb0QHQvUKQQ==",
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0",
@@ -4963,9 +4963,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.0.tgz",
-      "integrity": "sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+      "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
       "requires": {
         "@babel/types": "^7.3.0"
       }
@@ -5277,6 +5277,11 @@
           }
         }
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/yargs": {
       "version": "13.0.11",
@@ -11981,6 +11986,12 @@
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
           }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
         }
       }
     },
@@ -24442,9 +24453,9 @@
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
     "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^1.1.0",
@@ -36530,10 +36541,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-      "dev": true
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -38087,9 +38097,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "7.1.1",

--- a/packages/claims/package.json
+++ b/packages/claims/package.json
@@ -37,9 +37,11 @@
     "@ew-did-registry/jwt": "0.1.0",
     "@ew-did-registry/keys": "0.1.0",
     "eciesjs": "^0.3.4",
-    "sjcl-complete": "1.0.0"
+    "sjcl-complete": "1.0.0",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "ganache-cli": "6.9.1"
   }
 }

--- a/packages/claims/src/claimsUser/claimsUser.ts
+++ b/packages/claims/src/claimsUser/claimsUser.ts
@@ -5,6 +5,7 @@ import { encrypt } from 'eciesjs';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import sjcl from 'sjcl-complete';
+import { v4 as uuid } from 'uuid';
 import assert from 'assert';
 import {
   Algorithms,
@@ -306,7 +307,12 @@ export class ClaimsUser extends Claims implements IClaimsUser {
       DIDAttribute.ServicePoint,
       {
         type: PubKeyType.VerificationKey2018,
-        value: { serviceEndpoint: url, hash: createHash(claim), hashAlg },
+        value: {
+          id: uuid(),
+          serviceEndpoint: url,
+          hash: createHash(claim),
+          hashAlg,
+        },
       },
     );
     return url;

--- a/packages/did-document/test/did-document-full.test.ts
+++ b/packages/did-document/test/did-document-full.test.ts
@@ -219,6 +219,19 @@ describe('[DID DOCUMENT FULL PACKAGE]', function () {
     expect(fullDoc.fromLogs(logs)).to.deep.equalInAnyOrder(await fullDoc.read(did));
   });
 
+  it('service endpoint should have key when read', async () => {
+    const updateData: IUpdateData = {
+      type: PubKeyType.VerificationKey2018,
+      value: { serviceEndpoint: 'my-endpoint', hash: 'hashOfToken' },
+    };
+    await fullDoc.update(DIDAttribute.ServicePoint, updateData, validity);
+
+    const logsUpToFirstUpdate = await fullDoc.readFromBlock(did, new BigNumber(0));
+    const serviceEndpointKeys = Object.keys(logsUpToFirstUpdate.service);
+
+    expect(serviceEndpointKeys.includes('undefined')).equal(false);
+  });
+
   it('logs order should not influence restored document', async () => {
     const updateData: IUpdateData = {
       algo: Algorithms.ED25519,

--- a/packages/did-ethr-resolver/package.json
+++ b/packages/did-ethr-resolver/package.json
@@ -31,6 +31,10 @@
     "@ew-did-registry/did-resolver-interface": "0.1.0",
     "@ew-did-registry/keys": "0.1.0",
     "@ew-did-registry/proxyidentity": "0.1.0",
-    "ethers": "4.0.45"
+    "ethers": "4.0.45",
+    "uuid": "^8.3.1"
+  },
+  "devDependencies": {
+    "@types/uuid": "^8.3.0"
   }
 }

--- a/packages/did-ethr-resolver/src/functions/functions.ts
+++ b/packages/did-ethr-resolver/src/functions/functions.ts
@@ -151,6 +151,9 @@ const handleAttributeChange = (
         servicePoint.validity = validTo;
         servicePoint.block = block;
 
+        // Use the serviceEndpoint as id if none is provided
+        servicePoint.id = servicePoint.id ?? servicePoint.serviceEndpoint;
+
         if (document.service[servicePoint.id] === undefined
           || document.service[servicePoint.id].block < block) {
           document.service[servicePoint.id] = servicePoint;

--- a/packages/did-ethr-resolver/src/implementations/operator.ts
+++ b/packages/did-ethr-resolver/src/implementations/operator.ts
@@ -3,6 +3,7 @@
 import {
   Contract, ethers, Event, utils,
 } from 'ethers';
+import { v4 as uuid } from 'uuid';
 import {
   Algorithms,
   DIDAttribute,
@@ -92,7 +93,7 @@ export class Operator extends Resolver implements IOperator {
       algo: Algorithms.Secp256k1,
       type: PubKeyType.VerificationKey2018,
       encoding: Encoding.HEX,
-      value: { publicKey: `0x${this.getPublicKey()}`, tag: KeyTags.OWNER },
+      value: { id: uuid(), publicKey: `0x${this.getPublicKey()}`, tag: KeyTags.OWNER },
     };
     const validity = 10 * 60 * 1000;
     await this.update(did, attribute, updateData, validity);
@@ -350,6 +351,7 @@ export class Operator extends Resolver implements IOperator {
       const publicKeyTag = pk.id.split('#')[1];
 
       const keyValue: IAttributePayload = {
+        id: 'NEED TO DETERMINE',
         publicKey: value,
         tag: publicKeyTag,
       };

--- a/packages/did-resolver-interface/src/models/operator.ts
+++ b/packages/did-resolver-interface/src/models/operator.ts
@@ -37,7 +37,7 @@ export enum KeyTags {
  * TODO : avoid use of IAttributePayload, reuse IPublicKey and IServiceEndpoint
 */
 export interface IAttributePayload {
-  id?: string;
+  id: string;
   type?: string;
   publicKey?: string;
   serviceEndpoint?: string;


### PR DESCRIPTION
### Summary
|             |   |
|-------------|---|
| Description | Inclusion of the "id" property of IAttributePayload is not enforced, however resolution of the Service Endpoint  expects that "id" is present. If no "id" is given, a key of "undefined" is given to the service endpoint in `handleAttributeChange`. If several service endpoints without ids are in the events, then only the most recent will be in the resolved document.  |
| Jira issue  | none  |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Features
This PR adds:
- A test in `did-document-full.test.ts` which demonstrates the issue
- A possible fix that uses the "serviceEndpoint" as a default "id" if none is present. Probably a better solution (maybe in addition to this change), would be to enforce that "id" is provided when creating a service endpoint.