### PR TITLE
fix: add package-locks to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-packages/**/package-lock.json
 .idea
 **/*.map
 docs


### PR DESCRIPTION
`lerna` requires package-locks to commit when publishing