### PR TITLE
feature/skip verify claim requester

### DIFF
--- a/packages/claims/src/claimsIssuer/claimsIssuer.ts
+++ b/packages/claims/src/claimsIssuer/claimsIssuer.ts
@@ -27,9 +27,6 @@ export class ClaimsIssuer extends Claims implements IClaimsIssuer {
    */
   async issuePublicClaim(token: string): Promise<string> {
     const claim: IPublicClaim = this.jwt.decode(token) as IPublicClaim;
-    if (!(await this.verifySignature(token, claim.iss as string))) {
-      throw new Error('User signature not valid');
-    }
     claim.signer = this.did;
     delete claim.iss;
     const signedToken = await this.jwt.sign(

--- a/packages/claims/test/claimsIssuer.test.ts
+++ b/packages/claims/test/claimsIssuer.test.ts
@@ -65,17 +65,6 @@ describe('[CLAIMS PACKAGE/ISSUER CLAIMS]', function () {
     return claimsIssuer.issuePublicClaim(token).should.be.fulfilled;
   });
 
-  it('issuer must reject to issue token signed by non-owner', async () => {
-    let token = await claimsUser.createPublicClaim({});
-    const unauthorized = new Keys();
-    const jwt = new JWT(unauthorized);
-    const payload = jwt.decode(token);
-    token = await jwt.sign(payload, {
-      noTimestamp: true,
-    });
-    return claimsIssuer.issuePublicClaim(token).should.be.rejected;
-  });
-
   it('claim issued by delegate should be verified', async () => {
     await userDoc.update(
       DIDAttribute.Authenticate,


### PR DESCRIPTION
### Summary
|||
|-|-|
| Description | Since there are no limitations on who is allowed to request claim for given subject or how to verify claim accuracy claim verification upon issuance can be skiped |
| Jira issue  | https://energyweb.atlassian.net/browse/SWTCH-799 |