### PR TITLE
fix(interfaces): remove the duplicated IdentityOwner from interfaces

### DIFF
--- a/packages/did-resolver-interface/src/models/resolver.ts
+++ b/packages/did-resolver-interface/src/models/resolver.ts
@@ -1,6 +1,5 @@
 import {
   utils,
-  Signer,
   BigNumber,
   providers,
   ContractInterface,
@@ -162,11 +161,6 @@ export interface IDIDLogData {
 export enum DelegateTypes {
   authentication = 'sigAuth',
   verification = 'veriKey',
-}
-
-export interface IdentityOwner extends Signer {
-  publicKey: string;
-  privateKey?: string;
 }
 
 export type DocumentSelector = Partial<{


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description |  Fixing duplication Issue  on did-resolver-interface package|
| Github issue  |  #317  |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Features

- Remove the duplicated IdentityOwner from interfaces
- Remove the unsued `Signer` function from did-resolver-interface
