### PR TITLE
bug/EDR-30 Can't extend EwSigner from Signer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules
 **/*.map
 docs
 build
-!packages/proxyIdentity/build
 dist
 *.d.ts
 !typings/**/*.d.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es6",
     "declaration": true,
     "sourceMap": true,
     "noImplicitAny": true,


### PR DESCRIPTION
### Summary

| Description | Instantiation of EwSigner throws `constructor can not be invoked without new` |
| Jira issue  | https://energyweb.atlassian.net/browse/EDR-30 |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix

Fixes:
- compile to es6 to enable extending from es6 classes such as `ethers.Signer`
- As repository should contain only source code contract artifacts from proxy identity will be build when installing package