### PR TITLE
feat(EwJsonRpcSigner): construct from ethers provider

### DIFF
--- a/packages/did-ethr-resolver/src/implementations/ewJsonRcpSigner.ts
+++ b/packages/did-ethr-resolver/src/implementations/ewJsonRcpSigner.ts
@@ -1,28 +1,43 @@
 import { providers } from 'ethers';
 import { EwSigner } from './ewSigner';
 
-/**
-* Enables the ability to sign trasactions using an EIP-1193 web3 provider like Metamask
-*
-* @example
-* ```typescript
-* import { Operator, IdentityOwner, EwJsonRpcSigner } from '@ew-did-registry/did-resolver';
-* import detectMetamask from "@metamask/detect-provider";
-*
-* const web3Provider = await detectMetamask();
-* const web3Signer = new EwJsonRpcSigner(web3Provider);
-* const web3IdentityOwner = IdentityOwner.fromJsonRpcSigner(web3Signer, publicKey);
-*
-* const operator = new Operator(web3IdentityOwner, registrySettings);
-* ```
-* @param web3Provider: an EIP1193 provider
-*/
-
 type Web3ProviderType = providers.ExternalProvider | providers.JsonRpcFetchFunc;
 
+/**
+ * An encapsulation of an ethers JsonRpcSigner.
+ * This is to allow consumers more flexibility in the ethers version they can use.
+ */
 export class EwJsonRpcSigner extends EwSigner {
-  constructor(web3Provider: Web3ProviderType) {
-    const jsonRpcSigner = new providers.Web3Provider(web3Provider).getSigner();
-    super(jsonRpcSigner);
+  /**
+   * Allows the creation of EwJsonRpcSigner using an ethers Provider.
+   * This is convenient if a suitable ethers provider is available
+   * @param provider an ethers JsonPrcProvider or Web3Provider, with an associated signer
+   */
+  constructor(provider: providers.JsonRpcProvider | providers.Web3Provider) {
+    const signer = provider.getSigner();
+    super(signer);
+  }
+
+  /**
+  * A factory method to create a EwJsonRpcSigner without needing a specific ethers object.
+  * Instead, any object which conforms to the necessary interface can be used.
+  * See https://docs.ethers.io/v5/api/providers/other/#Web3Provider for interface description.
+  *
+  * @example
+  * ```typescript
+  * import { Operator, IdentityOwner, EwJsonRpcSigner } from '@ew-did-registry/did-resolver';
+  * import detectMetamask from "@metamask/detect-provider";
+  *
+  * const web3Provider = await detectMetamask();
+  * const web3Signer = EwJsonRpcSigner.fromWeb3Provider(web3Provider);
+  * const web3IdentityOwner = IdentityOwner.fromJsonRpcSigner(web3Signer, publicKey);
+  *
+  * const operator = new Operator(web3IdentityOwner, registrySettings);
+  * ```
+  * @param web3Provider an EIP1193 provider (https://docs.ethers.io/v5/api/providers/other/#Web3Provider)
+  */
+  public static fromWeb3Provider(web3Provider: Web3ProviderType): EwJsonRpcSigner {
+    const provider = new providers.Web3Provider(web3Provider);
+    return new EwJsonRpcSigner(provider);
   }
 }

--- a/packages/did-ethr-resolver/src/implementations/ewSigner.ts
+++ b/packages/did-ethr-resolver/src/implementations/ewSigner.ts
@@ -2,6 +2,7 @@ import { Signer, providers, utils } from 'ethers';
 
 /**
  * A base signer class that encapsulates the ethers Signer.
+ * The purpose of this encapsulation is to allow consumers more flexiblity in ethers version.
  */
 export abstract class EwSigner extends Signer {
   constructor(


### PR DESCRIPTION
EDR-37 https://energyweb.atlassian.net/browse/EDR-37

### Summary

|             |   |
|-------------|---|
| Description | EKC is providing an ethers JsonRPCProvider. It would be convenient therefore to be able to create an EwJsonRpcSigner from a JsonRpcProvider.  |
| Jira issue  |  https://energyweb.atlassian.net/browse/EDR-37 |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

### List of Features

- Allows the creation of EwJsonRpcSigner using an ethers Provider
