### PR TITLE
feat(EwSigner): add fromEthersSigner

### DIFF
--- a/packages/did-ethr-resolver/src/implementations/ewSigner.ts
+++ b/packages/did-ethr-resolver/src/implementations/ewSigner.ts
@@ -79,7 +79,7 @@ export class EwSigner extends Signer {
    * A factory method to create an EwSigner using an ethers library Signer.
    * This is convenient if a suitable ethers signer is available.
    * If instead an EIP1993 provider is available, see {@linkcode fromEIP1193}
-   * @param signer an ethers JsonPrcProvider or Web3Provider, with an associated signer
+   * @param signer an ethers Signer connected to chain
    * @param publicKey the publicKey of the signer associated with the provider
    */
   public static fromEthersSigner(signer: Signer, publicKey: string): EwSigner {

--- a/packages/did-ethr-resolver/test/ewSigner.test.ts
+++ b/packages/did-ethr-resolver/test/ewSigner.test.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { expect } from 'chai';
+import { providers, Wallet } from 'ethers';
+import { EwSigner } from '../src/implementations';
+
+describe('[RESOLVER PACKAGE]: EWSIGNER', () => {
+  it('instantiation from provider without signer should throw error', async () => {
+    const signer = Wallet.createRandom();
+    expect(() => EwSigner.fromEthersSigner(signer, '')).to.throw();
+  });
+
+  it('instantiation from signer with provider should not throw error', async () => {
+    const provider = new providers.JsonRpcProvider();
+    const signer = Wallet.createRandom().connect(provider);
+    EwSigner.fromEthersSigner(signer, '');
+  });
+});


### PR DESCRIPTION

### Summary

add `fromEthersSigner` also removed fromEthersProvider as it is not necessary to have. It makes more sense to create from signer as we are creating a EW"Signer". 
Also, added check that signer is actually available if creating from EIP1193. This is kinda of the issue that the EKC team had where they had a provider that wasn't actually connected to a signer. So better to check early.
|             |   |
|-------------|---|
| Jira issue  | https://energyweb.atlassian.net/browse/EDR-43 |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] New feature  **It is a breaking change** because removed `fromEthersProvider`
