### PR TITLE
test(claimsUser): verification of key with hex prefix

### DIFF
--- a/packages/claims/test/claimsUser.test.ts
+++ b/packages/claims/test/claimsUser.test.ts
@@ -1,5 +1,6 @@
 import { decrypt } from 'eciesjs';
 import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { Keys } from '@ew-did-registry/keys';
 import { Methods } from '@ew-did-registry/did';
 import {
@@ -7,11 +8,13 @@ import {
 } from '@ew-did-registry/did-ethr-resolver';
 import { DidStore } from '@ew-did-registry/did-ipfs-store';
 import { DIDDocumentFull } from '@ew-did-registry/did-document';
+import { ProviderSettings, ProviderTypes } from '@ew-did-registry/did-resolver-interface';
 import {
   ClaimsUser, IClaimsUser, IPrivateClaim, IProofClaim,
 } from '../src';
 import { deployRegistry, shutDownIpfsDaemon, spawnIpfsDaemon } from '../../../tests';
-import { ProviderSettings, ProviderTypes } from '@ew-did-registry/did-resolver-interface';
+
+chai.use(chaiAsPromised);
 chai.should();
 
 const claimData = {
@@ -26,7 +29,7 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
   this.timeout(0);
   const userKeys = new Keys();
   const userAddress = userKeys.getAddress();
-  const userDdid = `did:${Methods.Erc1056}:${userAddress}`;
+  const userDid = `did:${Methods.Erc1056}:${userAddress}`;
   const user = EwSigner.fromPrivateKey(userKeys.privateKey, providerSettings);
 
   const issuerKeys = new Keys();
@@ -35,14 +38,16 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
   const issuer = EwSigner.fromPrivateKey(issuerKeys.privateKey, providerSettings);
 
   let userClaims: IClaimsUser;
+  let store: DidStore;
+  let registry: string;
 
   before(async () => {
-    const registry = await deployRegistry([issuerAddress, userAddress]);
+    registry = await deployRegistry([issuerAddress, userAddress]);
     console.log(`registry: ${registry}`);
 
-    const store = new DidStore(await spawnIpfsDaemon());
+    store = new DidStore(await spawnIpfsDaemon());
     const userDoc = new DIDDocumentFull(
-      userDdid,
+      userDid,
       new Operator(
         user,
         { address: registry },
@@ -76,8 +81,8 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
       token, userClaims.keys.publicKey, { noTimestamp: true },
     );
     claim.should.deep.include({
-      did: userDdid,
-      signer: userDdid,
+      did: userDid,
+      signer: userDid,
       claimData: publicData,
     });
   });
@@ -112,7 +117,7 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
     const proofData = { secret: { value: '123abc', encrypted: true } };
     const token = await userClaims.createProofClaim(claimUrl, proofData);
     const claim = await userClaims.jwt.verify(token, userClaims.keys.publicKey, { noTimestamp: true }) as IProofClaim;
-    claim.should.include({ did: userDdid, signer: userDdid, claimUrl });
+    claim.should.include({ did: userDid, signer: userDid, claimUrl });
     claim.should.have.nested.property('proofData.secret.value.h').which.instanceOf(Array);
     claim.should.have.nested.property('proofData.secret.value.s').which.instanceOf(Array);
   });
@@ -122,6 +127,38 @@ describe('[CLAIMS PACKAGE/USER CLAIMS]', function () {
 
     const url = await userClaims.publishPublicClaim(claim, claimData);
 
+    return userClaims.verify(url).should.be.fulfilled;
+  });
+
+  /**
+   * publicKeyHex property of W3C security vocab does not have 0x prefix
+   * However, historically, some keys were added to DID Documents with a 0x prefix
+   * Therefore, the verification should be able to handle both.
+   * https://w3c-ccg.github.io/security-vocab/#publicKeyHex
+   * https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/
+   */
+  it('verifies claim of user with secp256k1 key with 0x prefix', async () => {
+    const keys = new Keys();
+    const address = keys.getAddress();
+    const did = `did:${Methods.Erc1056}:${address}`;
+    const signerWithHexPrefixKey = EwSigner.fromPrivateKey(userKeys.privateKey, providerSettings);
+    const compressedSecp256k1KeyLength = 66; // Expected that key is compressed without hex prefix
+    signerWithHexPrefixKey.publicKey.length.should.equal(compressedSecp256k1KeyLength);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    signerWithHexPrefixKey.publicKey = `0x${signerWithHexPrefixKey.publicKey}`;
+
+    const doc = new DIDDocumentFull(
+      did,
+      new Operator(
+        signerWithHexPrefixKey,
+        { address: registry },
+      ),
+    );
+    const userWithHexPrefixKey = new ClaimsUser(signerWithHexPrefixKey, doc, store);
+
+    const claim = await userWithHexPrefixKey.createPublicClaim(claimData);
+    const url = await userClaims.publishPublicClaim(claim, claimData);
     return userClaims.verify(url).should.be.fulfilled;
   });
 });

--- a/packages/did-ethr-resolver/src/implementations/resolver.ts
+++ b/packages/did-ethr-resolver/src/implementations/resolver.ts
@@ -16,6 +16,7 @@ import {
 import { Methods, DIDPattern } from '@ew-did-registry/did';
 import { ethrReg } from '../constants';
 import { fetchDataFromEvents, wrapDidDocument, query } from '../functions';
+import { compressedSecp256k1KeyLength } from '..';
 
 const { formatBytes32String } = utils;
 
@@ -175,7 +176,17 @@ class Resolver implements IResolver {
       did,
       selector,
     );
-    return pk ? ((pk as IPublicKey).publicKeyHex as string) : undefined;
+    const publicKeyHex = pk ? ((pk as IPublicKey).publicKeyHex as string) : undefined;
+    if (!publicKeyHex) {
+      return undefined;
+    }
+    if (publicKeyHex.length === compressedSecp256k1KeyLength + 2 && publicKeyHex.substring(0, 2) === '0x') {
+      return publicKeyHex.substring(2);
+    }
+    if (publicKeyHex.length === compressedSecp256k1KeyLength) {
+      return publicKeyHex;
+    }
+    return undefined;
   }
 
   async readFromBlock(

--- a/packages/did-ethr-resolver/src/utils/crypto.ts
+++ b/packages/did-ethr-resolver/src/utils/crypto.ts
@@ -7,6 +7,8 @@ const {
   keccak256, hashMessage, arrayify, computePublicKey, recoverPublicKey,
 } = utils;
 
+export const compressedSecp256k1KeyLength = 66;
+
 export const walletPubKey = (
   { privateKey }: Wallet,
 ): string => new Keys({ privateKey: privateKey.slice(2) }).publicKey;

--- a/packages/did-ethr-resolver/test/did-operator.test.ts
+++ b/packages/did-ethr-resolver/test/did-operator.test.ts
@@ -53,6 +53,10 @@ const testSuite = (): void => {
     expect(operator.getPublicKey()).equal(keys.publicKey);
   });
 
+  it('readOwnerPubKey should give same publicKey', async () => {
+    expect(await operator.readOwnerPubKey(did)).equal(keys.publicKey);
+  });
+
   /**
    * Spy on a method call from resolver (i.e. identityOwner())
    * This is to ensure the provider from signer is used.


### PR DESCRIPTION
### Summary

- [x] write claims verification test
- [x] write ownerPubKey test
- [x] fix issues

|             |   |
|-------------|---| 
| Description | fix(resolver): readOwnerPubKey() handle key with 0x. Keys in DID document can have 0x prefix and so need to handle this case. Note that new didDocs are created with a key without the prefix   |
| Jira issue  | https://energyweb.atlassian.net/browse/ICL-105  |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
