### PR TITLE
chore(deploy.yml): use npm ci instead of npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install package
         run: |
-          npm install
+          npm ci
           npm run setup
 
       - name: Build package


### PR DESCRIPTION
npm ci does not modify the package-lock.json.
This ensures that exact packages are obtained.
This PR is motivated by this build failure: https://github.com/energywebfoundation/ew-did-registry/runs/3744856039?check_suite_focus=true