### PR TITLE
Set token to enable ci write access on dev branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
             NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         
       - name: Commit to develop branch and merge to master branch
+        if: github.ref == 'refs/heads/master'
         run: |
           git checkout development
           git merge origin/master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,10 +56,11 @@ jobs:
 
       - name: Deploy on development branch
         if: github.ref == 'refs/heads/development'
+        uses: codfish/semantic-release-action@v1
         env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_CI }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          npm run publish:canary
 
       - name: Deploy on master branch
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description |  When deploying on develop branch from github action, the workflow breaks due since this branch is a protected one which only accept merges after at least one review on Pull Request. This PR gives the github action direct write acess using a github token credited with this right |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Features

- Setting NPM Token
- Setting Github Token
- using Semantic-release-action@v
