### PR TITLE
fix/EDR-74-0x-Prefix (#341)

### DIFF
--- a/packages/did-document/test/did-document-full.test.ts
+++ b/packages/did-document/test/did-document-full.test.ts
@@ -58,6 +58,12 @@ describe('[DID DOCUMENT FULL PACKAGE]', function () {
     expect(created).to.be.true;
   });
 
+  it('create document public key should have 0x prefix', async () => {
+    const doc = await fullDoc.read(did);
+    expect(doc.publicKey).to.be.lengthOf(1);
+    expect(doc.publicKey[0]?.publicKeyHex?.slice(0, 2)).to.eql('0x');
+  });
+
   it('update document public key should return true', async () => {
     const updated = await fullDoc.update(
       DIDAttribute.PublicKey,

--- a/packages/did-ethr-resolver/src/implementations/operator.ts
+++ b/packages/did-ethr-resolver/src/implementations/operator.ts
@@ -104,7 +104,7 @@ export class Operator extends Resolver implements IOperator {
       algo: Algorithms.Secp256k1,
       type: PubKeyType.VerificationKey2018,
       encoding: Encoding.HEX,
-      value: { publicKey: this.getPublicKey(), tag: KeyTags.OWNER },
+      value: { publicKey: `0x${this.getPublicKey()}`, tag: KeyTags.OWNER },
     };
     await this.update(did, attribute, updateData);
     return true;

--- a/packages/did-ethr-resolver/src/utils/crypto.ts
+++ b/packages/did-ethr-resolver/src/utils/crypto.ts
@@ -4,7 +4,7 @@ import { Encoding, IPublicKey } from '@ew-did-registry/did-resolver-interface';
 import { DIDPattern } from '@ew-did-registry/did';
 
 const {
-  keccak256, hashMessage, arrayify, computePublicKey, recoverPublicKey,
+  keccak256, hashMessage, arrayify, computePublicKey, recoverPublicKey, hexlify,
 } = utils;
 
 export const compressedSecp256k1KeyLength = 66;
@@ -14,7 +14,7 @@ export const walletPubKey = (
 ): string => new Keys({ privateKey: privateKey.slice(2) }).publicKey;
 
 export async function signerPubKey(signer: Signer): Promise<string> {
-  const msg = 'Hello';
+  const msg = hexlify(123);
   const hash = keccak256(msg);
   const digest = hashMessage(arrayify(hash));
   const signature = await signer.signMessage(arrayify(digest));

--- a/packages/did-ethr-resolver/test/ewSigner.test.ts
+++ b/packages/did-ethr-resolver/test/ewSigner.test.ts
@@ -1,17 +1,66 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import { ProviderSettings, ProviderTypes } from '@ew-did-registry/did-resolver-interface';
 import { expect } from 'chai';
 import { providers, Wallet } from 'ethers';
+import { signerPubKey } from '../dist';
 import { EwSigner } from '../src/implementations';
 
+const SECP256K1_COMRESSED_KEY_LENGTH = 66;
+
 describe('[RESOLVER PACKAGE]: EWSIGNER', () => {
-  it('instantiation from provider without signer should throw error', async () => {
+  it('instantiation from privateKey should give publicKey without 0x prefix and 66 char length', async () => {
+    const signer = Wallet.createRandom();
+    const providerSettings: ProviderSettings = {
+      type: ProviderTypes.HTTP,
+    };
+    const ewSignerPubKey = EwSigner.fromPrivateKey(signer.privateKey, providerSettings).publicKey;
+    expect(ewSignerPubKey.slice(0, 2)).to.not.equal('0x');
+    expect(ewSignerPubKey).to.be.lengthOf(SECP256K1_COMRESSED_KEY_LENGTH);
+  });
+
+  it('instantiation from ethers signer with non-prefixed key does not add prefix', async () => {
+    const provider = new providers.JsonRpcProvider();
+    const signer = Wallet.createRandom().connect(provider);
+    const pubKey = await signerPubKey(signer);
+    expect(pubKey.slice(0, 2)).to.not.equal('0x');
+    const ewSignerPubKey = EwSigner.fromEthersSigner(signer, pubKey).publicKey;
+    expect(ewSignerPubKey).to.equal(pubKey);
+    expect(ewSignerPubKey).to.be.lengthOf(SECP256K1_COMRESSED_KEY_LENGTH);
+  });
+
+  it('instantiation from ethers signer with prefixed key removes prefix', async () => {
+    const provider = new providers.JsonRpcProvider();
+    const signer = Wallet.createRandom().connect(provider);
+    const pubKey = await signerPubKey(signer);
+    expect(pubKey.slice(0, 2)).to.not.equal('0x');
+    const prefixedKey = `0x${pubKey}`;
+    const ewSignerPubKey = EwSigner.fromEthersSigner(signer, prefixedKey).publicKey;
+    expect(ewSignerPubKey).to.equal(pubKey);
+    expect(ewSignerPubKey).to.be.lengthOf(SECP256K1_COMRESSED_KEY_LENGTH);
+  });
+
+  it('instantiation from ethers signer should throw if publicKey is not valid secp256k1 key', async () => {
+    const provider = new providers.JsonRpcProvider();
+    const signer = Wallet.createRandom().connect(provider);
+    const pubKey = '0x123';
+    expect(() => EwSigner.fromEthersSigner(signer, pubKey)).to.throw(Error);
+  });
+
+  it('instantiation from ethers signer without provider should throw error', async () => {
     const signer = Wallet.createRandom();
     expect(() => EwSigner.fromEthersSigner(signer, '')).to.throw();
   });
 
-  it('instantiation from signer with provider should not throw error', async () => {
+  it('instantiation from ethers signer with empty public key should throw error', async () => {
     const provider = new providers.JsonRpcProvider();
     const signer = Wallet.createRandom().connect(provider);
-    EwSigner.fromEthersSigner(signer, '');
+    expect(() => EwSigner.fromEthersSigner(signer, '')).to.throw();
+  });
+
+  it('instantiation from ethers signer with provider should not throw error', async () => {
+    const provider = new providers.JsonRpcProvider();
+    const signer = Wallet.createRandom().connect(provider);
+    const pubKey = await signerPubKey(signer);
+    EwSigner.fromEthersSigner(signer, pubKey);
   });
 });


### PR DESCRIPTION
### Summary
Merging bug fix for EDR-74 into master so that we can update iam-client-lib with stable version

#### Changes:
* test(did-doc-full): test for prefix in key of created doc

* test(ewSigner): testing key length and empty key

* fix(operator): moving addition of `0x` to operator


