### PR TITLE
EDR-81: Optimize master publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: cancel-previous
+    permissions:
+      contents: write
+      deployments: write
+      packages: write
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN_CI }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '14.17.6'
@@ -58,7 +62,7 @@ jobs:
       - name: Deploy on development branch
         if: github.ref == 'refs/heads/development'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_CI }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
@@ -67,7 +71,7 @@ jobs:
       - name: Deploy on master branch
         if: github.ref == 'refs/heads/master'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_CI }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm run publish:release
@@ -76,12 +80,16 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: deploy
+    permissions:
+      contents: write
+      deployments: write
+      packages: write
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: development
-          token: ${{ secrets.GH_TOKEN_CI }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit to develop branch and merge to master branch
         run: |


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description |  When publishing on ew-did-registry master branch, lerna makes a push on the branch which is causing a useless second run of the github action workflow. This PR resolves this issue by setting write [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) on GITHUB_TOKEN to replace [Personal Acces Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (labeled GH_TOKEN_CI) we were using. |
| Jira issue  |  https://energyweb.atlassian.net/browse/EDR-81  |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Fixes

- Setting write permissions on GITHUB_TOKEN
