### PR TITLE
fix(deploy.yml): preventing double run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
           access_token: ${{ github.token }}
 
   deploy:
+    if: "!contains(github.event.head_commit.author.name, 'GITHUB_ACTION')"
     runs-on: ubuntu-latest
     needs: cancel-previous
     steps:
@@ -70,6 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_CI }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          git config user.name "GITHUB_ACTION"
           npm run publish:release
         
   sync_master_to_development_branch :


### PR DESCRIPTION

### Summary

|             |   |
|-------------|---|
| Description |   Changing UserName to identify github action push. 
Since it is quite difficult to be sure of the exact scope of changes that lerna does on push, the idea of the fix is to not list all the file changes to ignore, but instead to avoid workflow running if the triggering event is the github action itself. Implementing [this](https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/17) pattern |
| Jira issue  |   |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

