### PR TITLE
feature/PDA-18 verification code consolidation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,10 @@
       {
         "allowEmptyCatch": true
       }
-    ]
+    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
+    "implicit-arrow-linebreak": "off"
   },
   "settings": {
     "import/resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7581,9 +7581,9 @@
       "integrity": "sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.2.tgz",
-      "integrity": "sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ=="
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.3.tgz",
+      "integrity": "sha512-2ELsJkBQ0xirVQnx0utl3N+/iTPF+S0r3j0IVQIMG0HgAWreFXumY+yhGcwSV5JZ/yNNAXWR4mjIYRH/FEgu2Q=="
     },
     "@openzeppelin/truffle-upgrades": {
       "version": "1.10.0",
@@ -10805,9 +10805,9 @@
       }
     },
     "@types/sinon-chai": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
-      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.6.tgz",
+      "integrity": "sha512-Z57LprQ+yOQNu9d6mWdHNvnmncPXzDWGSeLj+8L075/QahToapC4Q13zAFRVKV4clyBmdJ5gz4xBfVkOso5lXw==",
       "requires": {
         "@types/chai": "*",
         "@types/sinon": "*"
@@ -19151,7 +19151,7 @@
         "@ledgerhq/hw-transport-webusb": "^5.22.0",
         "@nodefactory/filsnap-adapter": "^0.2.1",
         "@nodefactory/filsnap-types": "^0.2.1",
-        "@zondax/filecoin-signing-tools": "@zondax/filecoin-signing-tools@github:Digital-MOB-Filecoin/filecoin-signing-tools-js",
+        "@zondax/filecoin-signing-tools": "github:Digital-MOB-Filecoin/filecoin-signing-tools-js",
         "bignumber.js": "^9.0.0",
         "bitcore-lib": "^8.22.2",
         "bitcore-mnemonic": "^8.22.2",
@@ -43509,9 +43509,9 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "prettier": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-          "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+          "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg=="
         },
         "universalify": {
           "version": "0.1.2",

--- a/packages/claims/package.json
+++ b/packages/claims/package.json
@@ -37,10 +37,13 @@
     "@ew-did-registry/jwt": "0.6.0",
     "@ew-did-registry/keys": "0.6.0",
     "@types/sjcl": "1.0.28",
+    "base64url": "^3.0.1",
     "eciesjs": "^0.3.4",
+    "ethers": "^5.5.1",
     "sjcl": "npm:sjcl-complete@1.0.0"
   },
   "devDependencies": {
+    "chai": "^4.3.4",
     "ganache-cli": "^6.12.2",
     "run-with-testrpc": "0.3.1"
   }

--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -39,7 +39,7 @@ export class Claims implements IClaims {
   constructor(
     owner: EwSigner,
     protected document: IDIDDocumentFull,
-    protected store: IDidStore
+    protected store: IDidStore,
   ) {
     this.keys = { publicKey: owner.publicKey, privateKey: owner.privateKey };
     this.jwt = new JWT(owner);
@@ -76,7 +76,7 @@ export class Claims implements IClaims {
       issuerDoc?: IDIDDocument;
       holderDoc?: IDIDDocument;
       verificationPurpose?: VerificationPurpose;
-    } = {}
+    } = {},
   ): Promise<IPublicClaim | IPrivateClaim> {
     const token = await this.store.get(claimUrl);
     const claim = this.jwt.decode(token) as (IPublicClaim | IPrivateClaim) &
@@ -112,7 +112,7 @@ export class Claims implements IClaims {
 
   /**
    * @description Verifies that token stored at `claimUrl` is one of the services of `holderDoc`.
-   * 
+   *
    * @param claimUrl: url of the published claim
    * @param params.hashFns: The function used to determine the of hash of the claim
    * token used in the DID document. Used to verify that the DID document service endpoint
@@ -127,15 +127,15 @@ export class Claims implements IClaims {
     }: {
       hashFns?: { [alg: string]: (data: string) => string };
       holderDoc: IDIDDocument;
-    }
+    },
   ) {
     const token = await this.store.get(claimUrl);
     const service = holderDoc.service.find(
-      (s) => s.serviceEndpoint === claimUrl
+      (s) => s.serviceEndpoint === claimUrl,
     ) as IServiceEndpoint;
     if (!service) {
       throw new Error(
-        `No service endpoint found for ${claimUrl} in holder DID document`
+        `No service endpoint found for ${claimUrl} in holder DID document`,
       );
     }
     const { hash, hashAlg } = service;

--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -39,7 +39,7 @@ export class Claims implements IClaims {
   constructor(
     owner: EwSigner,
     protected document: IDIDDocumentFull,
-    protected store: IDidStore,
+    protected store: IDidStore
   ) {
     this.keys = { publicKey: owner.publicKey, privateKey: owner.privateKey };
     this.jwt = new JWT(owner);
@@ -48,10 +48,20 @@ export class Claims implements IClaims {
 
   /**
    * Verifies issuance and publishing of claim at `claimUrl`.
-   * On successful verification returns claim
+   * On success returns claim.
+   * Verification takes into account purpose on which claim was issued.
    *
-   * @param claimUrl {string}
-   * @param hashFns {{ [alg: string]: (data: string) => string }}
+   * @param claimUrl: Url of claim to be verified. This method will retrieve
+   * the claim using the didStore configured for the class
+   * @param params.hashFns: The function used to determine the of hash of the claim
+   * token used in the DID document. Used to verify that the DID document service endpoint
+   * matches the retrieved claim.
+   * @param params.issuerDoc: Document with verification methods to verify claim issuance with
+   * @param params.holderDoc: Document with service endpoints to verify claim publishing with
+   * @param params.verificationPurpose: Specifies which verification methods to use.
+   * `VerificationPurpose.Authenticate` is used to verify claim issued to authenticate identity
+   * `VerificationPurpose.Assertion` is used to assert issuer approval.
+   * By default verification asserts claim approval.
    *
    */
   async verify(
@@ -60,13 +70,13 @@ export class Claims implements IClaims {
       hashFns,
       issuerDoc,
       holderDoc,
-      verificationPurpose = VerificationPurpose.Authentication,
+      verificationPurpose = VerificationPurpose.Assertion,
     }: {
       hashFns?: { [alg: string]: (data: string) => string };
       issuerDoc?: IDIDDocument;
       holderDoc?: IDIDDocument;
       verificationPurpose?: VerificationPurpose;
-    } = {},
+    } = {}
   ): Promise<IPublicClaim | IPrivateClaim> {
     const token = await this.store.get(claimUrl);
     const claim = this.jwt.decode(token) as (IPublicClaim | IPrivateClaim) &
@@ -101,10 +111,13 @@ export class Claims implements IClaims {
   }
 
   /**
-   * @description Verifies that token stored at `claimUrl` represents service
-   * endpoint of `holderDoc`
-   * @param claimUrl
-   * @param param1
+   * @description Verifies that token stored at `claimUrl` is one of the services of `holderDoc`.
+   * 
+   * @param claimUrl: url of the published claim
+   * @param params.hashFns: The function used to determine the of hash of the claim
+   * token used in the DID document. Used to verify that the DID document service endpoint
+   * matches the retrieved claim.
+   * @param params.holderDod: Document in which to search for service endpoint.
    */
   async validateServiceEndpointToken(
     claimUrl: string,
@@ -114,14 +127,16 @@ export class Claims implements IClaims {
     }: {
       hashFns?: { [alg: string]: (data: string) => string };
       holderDoc: IDIDDocument;
-    },
+    }
   ) {
     const token = await this.store.get(claimUrl);
     const service = holderDoc.service.find(
-      (s) => s.serviceEndpoint === claimUrl,
+      (s) => s.serviceEndpoint === claimUrl
     ) as IServiceEndpoint;
     if (!service) {
-      throw new Error(`No service endpoint found for ${claimUrl} in holder DID document`);
+      throw new Error(
+        `No service endpoint found for ${claimUrl} in holder DID document`
+      );
     }
     const { hash, hashAlg } = service;
     const createHash = { ...hashes, ...hashFns }[hashAlg as string];

--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -146,7 +146,7 @@ export class Claims implements IClaims {
       (s) => s.serviceEndpoint === claimUrl,
     ) as IServiceEndpoint;
     if (!service) {
-      throw new Error(`No claim at ${claimUrl}`);
+      throw new Error(`No service endpoint found for ${claimUrl} in holder DID document`);
     }
     const { hash, hashAlg } = service;
     const createHash = { ...hashes, ...hashFns }[hashAlg as string];

--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -117,7 +117,7 @@ export class Claims implements IClaims {
    * @param params.hashFns: The function used to determine the of hash of the claim
    * token used in the DID document. Used to verify that the DID document service endpoint
    * matches the retrieved claim.
-   * @param params.holderDod: Document in which to search for service endpoint.
+   * @param params.holderDoc: Document in which to search for service endpoint.
    */
   async validateServiceEndpointToken(
     claimUrl: string,

--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -47,31 +47,6 @@ export class Claims implements IClaims {
   }
 
   /**
-   * Verifies signers signature on received token
-   * @example
-   * ```typescript
-   * import { Keys } from '@ew-did-registry/keys';
-   * import { Claims } from '@ew-did-registry/claims';
-   *
-   * const user = new Keys();
-   * const claims = new Claims(user);
-   * const verified = claims.verifySignature(token, userDid);
-   * ```
-   *
-   * @param { string } token token signature on which you want to check
-   * @param { string } signer did of the signer
-   */
-  async verifySignature(token: string, signer: string): Promise<boolean> {
-    const signerPubKey = await this.document.ownerPubKey(signer);
-    try {
-      await this.jwt.verify(token, signerPubKey as string);
-    } catch (error) {
-      return false;
-    }
-    return true;
-  }
-
-  /**
    * Verifies issuance and publishing of claim at `claimUrl`.
    * On successful verification returns claim
    *
@@ -115,7 +90,7 @@ export class Claims implements IClaims {
         }
         break;
       case VerificationPurpose.Assertion:
-        if (await tokenVerifier.verifyAssertionProof(token)) {
+        if (await proofVerifier.verifyAssertionProof(token)) {
           return claim;
         }
         break;

--- a/packages/claims/src/claims/claims.ts
+++ b/packages/claims/src/claims/claims.ts
@@ -107,15 +107,15 @@ export class Claims implements IClaims {
       holderDoc,
     });
 
-    const tokenVerifier = new ProofVerifier(issuerDoc);
+    const proofVerifier = new ProofVerifier(issuerDoc);
     switch (verificationPurpose) {
       case VerificationPurpose.Authentication:
-        if (await tokenVerifier.authenticate(token)) {
+        if (await proofVerifier.verifyAuthenticationProof(token)) {
           return claim;
         }
         break;
-      case VerificationPurpose.Verification:
-        if (await tokenVerifier.verify(token)) {
+      case VerificationPurpose.Assertion:
+        if (await tokenVerifier.verifyAssertionProof(token)) {
           return claim;
         }
         break;

--- a/packages/claims/src/claimsIssuer/claimsIssuer.ts
+++ b/packages/claims/src/claimsIssuer/claimsIssuer.ts
@@ -65,7 +65,7 @@ export class ClaimsIssuer extends Claims implements IClaimsIssuer {
     const g = curve.G;
     const claim: IPrivateClaim = this.jwt.decode(token) as IPrivateClaim;
     const proofVerifier = new ProofVerifier(await this.document.read(claim.signer));
-    if (!(await proofVerifier.verifyAuthenticationProof(token))) {
+    if (!(await proofVerifier.verifyAssertionProof(token))) {
       throw new Error('User signature not valid');
     }
     claim.signer = this.did;

--- a/packages/claims/src/claimsIssuer/claimsIssuer.ts
+++ b/packages/claims/src/claimsIssuer/claimsIssuer.ts
@@ -6,6 +6,7 @@ import { Algorithms } from '@ew-did-registry/jwt';
 import { IClaimsIssuer } from '../interface';
 import { Claims } from '../claims';
 import { IPrivateClaim, IPublicClaim } from '../models';
+import { ProofVerifier } from '..';
 
 export class ClaimsIssuer extends Claims implements IClaimsIssuer {
   /**
@@ -63,7 +64,8 @@ export class ClaimsIssuer extends Claims implements IClaimsIssuer {
     const curve: sjcl.SjclEllipticalCurve = ecc.curves.k256;
     const g = curve.G;
     const claim: IPrivateClaim = this.jwt.decode(token) as IPrivateClaim;
-    if (!(await this.verifySignature(token, claim.iss as string))) {
+    const proofVerifier = new ProofVerifier(await this.document.read(claim.signer));
+    if (!(await proofVerifier.verifyAuthenticationProof(token))) {
       throw new Error('User signature not valid');
     }
     claim.signer = this.did;

--- a/packages/claims/src/claimsUser/claimsUser.ts
+++ b/packages/claims/src/claimsUser/claimsUser.ts
@@ -65,7 +65,7 @@ export class ClaimsUser extends Claims implements IClaimsUser {
    *
    * @returns { Promise<string> }
    */
-  async createPublicClaim(publicData: object, jwtOptions = { subject: '', issuer: '' }): Promise<string> {
+  async createPublicClaim(publicData: Record<string, unknown>, jwtOptions = { subject: '', issuer: '' }): Promise<string> {
     jwtOptions.subject = jwtOptions.subject || this.did;
     jwtOptions.issuer = this.did;
     const claim: IPublicClaim = {
@@ -218,13 +218,13 @@ export class ClaimsUser extends Claims implements IClaimsUser {
    * @returns {Promise<string>}
    * @throws if the proof failed
    */
-  async verifyPublicClaim(token: string, verifyData: object): Promise<boolean> {
+  async verifyPublicClaim(token: string, verifyData: Record<string, unknown>): Promise<boolean> {
     const claim = this.jwt.decode(token) as IPublicClaim;
     const issuer = claim.iss as string;
     if (!(await this.verifySignature(token, issuer))) {
       throw new Error('Incorrect signature');
     }
-    assert.deepStrictEqual(claim.claimData, verifyData, 'Token payload doesn\'t match user data');
+    assert.deepStrictEqual(claim.claimData, verifyData, "Token payload doesn't match user data");
     const issIsDelegate = await this.document.isValidDelegate(DelegateTypes.verification, issuer);
     const owner = `did:${Methods.Erc1056}:${await this.document.getController()}`;
     return issIsDelegate || owner === issuer;
@@ -256,7 +256,7 @@ export class ClaimsUser extends Claims implements IClaimsUser {
       const fieldHash = crypto.createHash('sha256').update(value).digest('hex');
       const PK = this.g.mult(new bn(fieldHash));
       if (!bitArray.equal(claim.claimData[key] as [], PK.toBits())) {
-        throw new Error('Issued claim data doesn\'t match user data');
+        throw new Error("Issued claim data doesn't match user data");
       }
     }
     const [, , issAddress] = (claim.iss as string).split(':');
@@ -284,9 +284,7 @@ export class ClaimsUser extends Claims implements IClaimsUser {
      *
      * @returns {string} url of the saved claim
      */
-  async publishPublicClaim(
-    issued: string, verifyData: object, opts?: { hashAlg: string; createHash: (data: string) => string },
-  ): Promise<string> {
+  async publishPublicClaim(issued: string, verifyData: Record<string, unknown>, opts?: { hashAlg: string; createHash: (data: string) => string }): Promise<string> {
     const verified = await this.verifyPublicClaim(issued, verifyData);
     if (verified) {
       return this.addClaimToServiceEndpoints(issued, opts);
@@ -302,9 +300,7 @@ export class ClaimsUser extends Claims implements IClaimsUser {
    *
    * @returns {string} url of the saved claim
    */
-  async publishPrivateClaim(
-    issued: string, saltedFields: ISaltedFields, opts?: { hashAlg: string; createHash: (data: string) => string },
-  ): Promise<string> {
+  async publishPrivateClaim(issued: string, saltedFields: ISaltedFields, opts?: { hashAlg: string; createHash: (data: string) => string }): Promise<string> {
     const verified = await this.verifyPrivateClaim(issued, saltedFields);
     if (verified) {
       return this.addClaimToServiceEndpoints(issued, opts);

--- a/packages/claims/src/claimsVerifier/claimsVerifier.ts
+++ b/packages/claims/src/claimsVerifier/claimsVerifier.ts
@@ -1,7 +1,10 @@
 import {
   bn, hash, ecc, bitArray,
 } from 'sjcl';
-import { DelegateTypes } from '@ew-did-registry/did-resolver-interface';
+import {
+  DelegateTypes,
+  IDIDDocument,
+} from '@ew-did-registry/did-resolver-interface';
 import crypto from 'crypto';
 import { Claims } from '../claims';
 import { IClaimsVerifier } from '../interface';
@@ -25,28 +28,40 @@ export class ClaimsVerifier extends Claims implements IClaimsVerifier {
    * @returns { Promise<void> } whether the proof was succesfull
    * @throws if the proof failed
    */
-  async verifyPublicProof(claimUrl: string): Promise<IPublicClaim> {
-    return this.verify(claimUrl) as Promise<IPublicClaim>;
+  async verifyPublicProof(
+    claimUrl: string,
+    {
+      holderDoc,
+      issuerDoc,
+    }: {
+      holderDoc?: IDIDDocument;
+      issuerDoc?: IDIDDocument;
+    } = {},
+  ): Promise<IPublicClaim> {
+    return this.verify(claimUrl, {
+      holderDoc,
+      issuerDoc,
+    }) as Promise<IPublicClaim>;
   }
 
   /**
-  * Checks issuer signature on issued token and user signature on proof token
-  * and verifies that proof and private data mathches to each other
-  *
-  * @example
-  * ```typescript
-  * import { ClaimsVerifier } from '@ew-did-registry/claims';
-  * import { Keys } from '@ew-did-registry/keys';
-  *
-  * const keys = new Keys();
-  * const claims = new ClaimsVerifier(verifier);
-  * const verified = claims.verifyPrivateProof(proofToken);
-  * ```
-  * @param { string } proofToken contains proof data
-  * @param { string } privateToken contains private data
-  * @returns { Promise<void> } whether the proof was succesfull
-  * @throws if the proof failed
-  */
+   * Checks issuer signature on issued token and user signature on proof token
+   * and verifies that proof and private data mathches to each other
+   *
+   * @example
+   * ```typescript
+   * import { ClaimsVerifier } from '@ew-did-registry/claims';
+   * import { Keys } from '@ew-did-registry/keys';
+   *
+   * const keys = new Keys();
+   * const claims = new ClaimsVerifier(verifier);
+   * const verified = claims.verifyPrivateProof(proofToken);
+   * ```
+   * @param { string } proofToken contains proof data
+   * @param { string } privateToken contains private data
+   * @returns { Promise<void> } whether the proof was succesfull
+   * @throws if the proof failed
+   */
   async verifyPrivateProof(proofToken: string): Promise<void> {
     const { claimUrl } = this.jwt.decode(proofToken) as { claimUrl: string };
     const privateClaim = await this.verify(claimUrl);
@@ -57,14 +72,13 @@ export class ClaimsVerifier extends Claims implements IClaimsVerifier {
       throw new Error('Invalid signature');
     }
     if (
-      !this.document
-        .isValidDelegate(
-          DelegateTypes.verification,
-          privateClaim.signer,
-          privateClaim.did,
-        )
+      !this.document.isValidDelegate(
+        DelegateTypes.verification,
+        privateClaim.signer,
+        privateClaim.did,
+      )
     ) {
-      throw new Error('Issuer isn\'t a use\'r delegate');
+      throw new Error("Issuer isn't a user delegate");
     }
 
     const { proofData } = proofClaim;
@@ -79,25 +93,28 @@ export class ClaimsVerifier extends Claims implements IClaimsVerifier {
         h = curve.fromBits(h);
         s = bn.fromBits(s);
         const c = bn.fromBits(
-          hash.sha256.hash(
-            g.x.toBits()
-              .concat(h.toBits())
-              .concat(PK.toBits()),
-          ),
+          hash.sha256.hash(g.x.toBits().concat(h.toBits()).concat(PK.toBits())),
         );
         const left = g.mult(s);
         const right = PK.mult(c).toJac().add(h).toAffine();
         if (!bitArray.equal(left.toBits(), right.toBits())) {
-          throw new Error('User didn\'t prove the knowledge of the private data');
+          throw new Error(
+            "User didn't prove the knowledge of the private data",
+          );
         }
       } else {
-        const fieldHash = crypto.createHash('sha256').update(field.value as string).digest('hex');
+        const fieldHash = crypto
+          .createHash('sha256')
+          .update(field.value as string)
+          .digest('hex');
         // eslint-disable-next-line new-cap
         const PK = g.mult(new bn(fieldHash));
         const bitsPK = PK.toBits();
 
         if (!bitArray.equal(value as [], bitsPK)) {
-          throw new Error('Disclosed field does not correspond to stored field');
+          throw new Error(
+            'Disclosed field does not correspond to stored field',
+          );
         }
       }
     });

--- a/packages/claims/src/claimsVerifier/claimsVerifier.ts
+++ b/packages/claims/src/claimsVerifier/claimsVerifier.ts
@@ -68,9 +68,6 @@ export class ClaimsVerifier extends Claims implements IClaimsVerifier {
     const curve: sjcl.SjclEllipticalCurve = ecc.curves.k256;
     const g = curve.G;
     const proofClaim: IProofClaim = this.jwt.decode(proofToken) as IProofClaim;
-    if (!(await this.verifySignature(proofToken, proofClaim.signer))) {
-      throw new Error('Invalid signature');
-    }
     if (
       !this.document.isValidDelegate(
         DelegateTypes.verification,

--- a/packages/claims/src/claimsVerifier/claimsVerifier.ts
+++ b/packages/claims/src/claimsVerifier/claimsVerifier.ts
@@ -63,7 +63,7 @@ export class ClaimsVerifier extends Claims implements IClaimsVerifier {
    * @throws if the proof failed
    */
   async verifyPrivateProof(proofToken: string): Promise<void> {
-    const { claimUrl } = this.jwt.decode(proofToken) as { claimUrl: string };
+    const { claimUrl } = this.jwt.decode(proofToken) as IProofClaim;
     const privateClaim = await this.verify(claimUrl);
     const curve: sjcl.SjclEllipticalCurve = ecc.curves.k256;
     const g = curve.G;

--- a/packages/claims/src/claimsVerifier/index.ts
+++ b/packages/claims/src/claimsVerifier/index.ts
@@ -1,1 +1,2 @@
 export * from './claimsVerifier';
+export * from './proofVerifier';

--- a/packages/claims/src/claimsVerifier/proofVerifier.ts
+++ b/packages/claims/src/claimsVerifier/proofVerifier.ts
@@ -28,7 +28,7 @@ export class ProofVerifier {
    *
    * @param token
    *
-   * @returns {string} DID of authenticated identity
+   * @returns: DID of authenticated identity on successful verification or null otherwise
    */
   public async verifyAuthenticationProof(
     token: string,
@@ -43,10 +43,10 @@ export class ProofVerifier {
   }
 
   /**
-   * @description checks that token is issued by identity verification delegate
+   * @description Checks that token is issued by identity verification delegate
    *
-   * @param token
-   * @returns
+   * @param token: JWT token to verify
+   * @returns: DID of the authenticated identity on successful verification or null otherwise
    */
   public async verifyAssertionProof(token: string): Promise<string | null> {
     if (

--- a/packages/claims/src/claimsVerifier/proofVerifier.ts
+++ b/packages/claims/src/claimsVerifier/proofVerifier.ts
@@ -9,7 +9,9 @@ import {
 import { utils } from 'ethers';
 import base64url from 'base64url';
 
-const { arrayify, recoverAddress, keccak256, hashMessage } = utils;
+const {
+  arrayify, recoverAddress, keccak256, hashMessage,
+} = utils;
 
 export class ProofVerifier {
   private _jwt = new JWT(new Keys());
@@ -28,10 +30,10 @@ export class ProofVerifier {
    *
    * @returns {string} DID of authenticated identity
    */
-  public async authenticate(token: string): Promise<string | null> {
+  public async verifyAuthenticationProof(token: string): Promise<string | null> {
     if (
-      (await this.isIdentity(token)) ||
-      (await this.isAuthenticationDelegate(token))
+      (await this.isIdentity(token))
+      || (await this.isAuthenticationDelegate(token))
     ) {
       return this._didDocument.id;
     }
@@ -44,7 +46,7 @@ export class ProofVerifier {
    * @param token
    * @returns
    */
-  public async verify(token: string): Promise<string | null> {
+  public async verifyAssertionProof(token: string): Promise<string | null> {
     if (await this.isVerificationDelegate(token)) {
       return this._didDocument.id;
     }
@@ -59,7 +61,7 @@ export class ProofVerifier {
   private async isIdentity(token: string) {
     const [encodedHeader, encodedPayload, encodedSignature] = token.split('.');
     const msg = `0x${Buffer.from(`${encodedHeader}.${encodedPayload}`).toString(
-      'hex'
+      'hex',
     )}`;
     const signature = base64url.decode(encodedSignature);
     const hash = arrayify(keccak256(msg));
@@ -81,7 +83,7 @@ export class ProofVerifier {
   private async isAuthenticationDelegate(token: string) {
     const validKeys = await this.verifySignature(
       this.authenticationKeys(),
-      token
+      token,
     );
     return validKeys.length !== 0;
   }
@@ -89,7 +91,7 @@ export class ProofVerifier {
   private async isVerificationDelegate(token: string) {
     const validKeys = await this.verifySignature(
       this.verificationKeys(),
-      token
+      token,
     );
     return validKeys.length !== 0;
   }
@@ -112,8 +114,8 @@ export class ProofVerifier {
           } catch (error) {
             return false;
           }
-        }
-      )
+        },
+      ),
     );
 
     return keys.filter((_key, index) => results[index]);
@@ -126,12 +128,12 @@ export class ProofVerifier {
     }
     return didPubKeys.filter(
       (key) =>
-        this.isSigAuth(key.type) ||
-        this._didDocument.authentication.some(
+        this.isSigAuth(key.type)
+        || this._didDocument.authentication.some(
           (auth) =>
-            (auth as IAuthentication).publicKey &&
-            this.areLinked((auth as IAuthentication).publicKey, key.id)
-        )
+            (auth as IAuthentication).publicKey
+            && this.areLinked((auth as IAuthentication).publicKey, key.id),
+        ),
     );
   }
 

--- a/packages/claims/src/claimsVerifier/proofVerifier.ts
+++ b/packages/claims/src/claimsVerifier/proofVerifier.ts
@@ -1,0 +1,164 @@
+import { Algorithms, JWT } from '@ew-did-registry/jwt';
+import { Keys } from '@ew-did-registry/keys';
+import {
+  IAuthentication,
+  IDIDDocument,
+  IPublicKey,
+  PubKeyType,
+} from '@ew-did-registry/did-resolver-interface';
+import { utils } from 'ethers';
+import base64url from 'base64url';
+
+const { arrayify, recoverAddress, keccak256, hashMessage } = utils;
+
+export class ProofVerifier {
+  private _jwt = new JWT(new Keys());
+
+  private _didDocument: IDIDDocument;
+
+  constructor(didDocument: IDIDDocument) {
+    this._didDocument = didDocument;
+  }
+
+  /**
+   * @description checks that token was issued by identity represented by
+   * this verifier or his authentication delegate
+   *
+   * @param token
+   *
+   * @returns {string} DID of authenticated identity
+   */
+  public async authenticate(token: string): Promise<string | null> {
+    if (
+      (await this.isIdentity(token)) ||
+      (await this.isAuthenticationDelegate(token))
+    ) {
+      return this._didDocument.id;
+    }
+    return null;
+  }
+
+  /**
+   * @description checks that token is issued by identity verification delegate
+   *
+   * @param token
+   * @returns
+   */
+  public async verify(token: string): Promise<string | null> {
+    if (await this.isVerificationDelegate(token)) {
+      return this._didDocument.id;
+    }
+    return null;
+  }
+
+  /**
+   * @description Determines if a token was signed with an Ethereum signature
+   * by the address referenced by the id of the DID Document
+   * Note that JWT-compliant signatures can't be used to recover an ethereum
+   */
+  private async isIdentity(token: string) {
+    const [encodedHeader, encodedPayload, encodedSignature] = token.split('.');
+    const msg = `0x${Buffer.from(`${encodedHeader}.${encodedPayload}`).toString(
+      'hex'
+    )}`;
+    const signature = base64url.decode(encodedSignature);
+    const hash = arrayify(keccak256(msg));
+    const claimedAddress = this._didDocument.id.split(':')[2];
+    try {
+      if (claimedAddress === recoverAddress(hash, signature)) {
+        return true;
+      }
+    } catch (_) {}
+    const digest = arrayify(hashMessage(hash));
+    try {
+      if (claimedAddress === recoverAddress(digest, signature)) {
+        return true;
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  private async isAuthenticationDelegate(token: string) {
+    const validKeys = await this.verifySignature(
+      this.authenticationKeys(),
+      token
+    );
+    return validKeys.length !== 0;
+  }
+
+  private async isVerificationDelegate(token: string) {
+    const validKeys = await this.verifySignature(
+      this.verificationKeys(),
+      token
+    );
+    return validKeys.length !== 0;
+  }
+
+  private verifySignature = async (keys: IPublicKey[], token: string) => {
+    const results = await Promise.all(
+      keys.map(
+        async (pubKeyField: IPublicKey): Promise<boolean> => {
+          try {
+            if (pubKeyField.publicKeyHex) {
+              const parts = pubKeyField.publicKeyHex.split('x');
+              const publickey = parts.length === 2 ? parts[1] : parts[0];
+              const decodedClaim = await this._jwt.verify(token, publickey, {
+                algorithms: [Algorithms.ES256, Algorithms.EIP191],
+              });
+
+              return decodedClaim !== undefined;
+            }
+            return false;
+          } catch (error) {
+            return false;
+          }
+        }
+      )
+    );
+
+    return keys.filter((_key, index) => results[index]);
+  };
+
+  private authenticationKeys(): IPublicKey[] {
+    const didPubKeys = this._didDocument.publicKey;
+    if (didPubKeys.length === 0) {
+      return [];
+    }
+    return didPubKeys.filter(
+      (key) =>
+        this.isSigAuth(key.type) ||
+        this._didDocument.authentication.some(
+          (auth) =>
+            (auth as IAuthentication).publicKey &&
+            this.areLinked((auth as IAuthentication).publicKey, key.id)
+        )
+    );
+  }
+
+  private verificationKeys(): IPublicKey[] {
+    const didPubKeys = this._didDocument.publicKey;
+    if (didPubKeys.length === 0) {
+      return [];
+    }
+    return didPubKeys.filter((key) => this.isVeriKey(key.type));
+  }
+
+  // used to check if publicKey field in authentication refers to publicKey ID in publicKey field
+  private areLinked = (authId: string, pubKeyID: string) => {
+    if (authId === pubKeyID) {
+      return true;
+    }
+    if (authId.includes('#')) {
+      return pubKeyID.split('#')[0] === authId.split('#')[0];
+    }
+    return false;
+  };
+
+  private isSigAuth(pubKeyType: string) {
+    return pubKeyType.endsWith(PubKeyType.SignatureAuthentication2018);
+  }
+
+  private isVeriKey(pubKeyType: string) {
+    return pubKeyType.endsWith(PubKeyType.VerificationKey2018);
+  }
+}

--- a/packages/claims/src/claimsVerifier/proofVerifier.ts
+++ b/packages/claims/src/claimsVerifier/proofVerifier.ts
@@ -30,7 +30,9 @@ export class ProofVerifier {
    *
    * @returns {string} DID of authenticated identity
    */
-  public async verifyAuthenticationProof(token: string): Promise<string | null> {
+  public async verifyAuthenticationProof(
+    token: string,
+  ): Promise<string | null> {
     if (
       (await this.isIdentity(token))
       || (await this.isAuthenticationDelegate(token))
@@ -47,7 +49,10 @@ export class ProofVerifier {
    * @returns
    */
   public async verifyAssertionProof(token: string): Promise<string | null> {
-    if (await this.isVerificationDelegate(token)) {
+    if (
+      (await this.isIdentity(token))
+      || (await this.isVerificationDelegate(token))
+    ) {
       return this._didDocument.id;
     }
     return null;

--- a/packages/claims/src/interface.ts
+++ b/packages/claims/src/interface.ts
@@ -17,7 +17,7 @@ export interface IClaimsUser extends IClaims {
     issuer: string
   ): Promise<{ token: string; saltedFields: { [key: string]: string } }>;
   createProofClaim(claimUrl: string, saltedFields: IProofData): Promise<string>;
-  verifyClaimContent(token: string, verifyData: object): Promise<boolean>;
+  verifyClaimContent(token: string, verifyData: object): void;
   verifyPrivateClaim(
     privateToken: string,
     saltedFields: ISaltedFields

--- a/packages/claims/src/interface.ts
+++ b/packages/claims/src/interface.ts
@@ -1,4 +1,5 @@
-import { IClaims, IProofData, IPublicClaim, ISaltedFields, } from './models';
+import { IDIDDocument } from '@ew-did-registry/did-resolver-interface';
+import { IClaims, IProofData, IPublicClaim, ISaltedFields } from './models';
 
 /**
  * IClaims interface is a factory to create Public, Private, and Proof Claims
@@ -11,13 +12,26 @@ export interface IClaimsFactory {
 
 export interface IClaimsUser extends IClaims {
   createPublicClaim(publicData: object): Promise<string>;
-  createPrivateClaim(privateData: { [key: string]: string }, issuer: string):
-    Promise<{ token: string; saltedFields: { [key: string]: string } }>;
+  createPrivateClaim(
+    privateData: { [key: string]: string },
+    issuer: string
+  ): Promise<{ token: string; saltedFields: { [key: string]: string } }>;
   createProofClaim(claimUrl: string, saltedFields: IProofData): Promise<string>;
   verifyPublicClaim(token: string, verifyData: object): Promise<boolean>;
-  verifyPrivateClaim(privateToken: string, saltedFields: ISaltedFields): Promise<boolean>;
-  publishPublicClaim(issued: string, verifyData: object, opts?: { hashAlg: string; createHash: (data: string) => string }): Promise<string>;
-  publishPrivateClaim(issued: string, saltedFields: ISaltedFields, opts?: { hashAlg: string; createHash: (data: string) => string }): Promise<string>;
+  verifyPrivateClaim(
+    privateToken: string,
+    saltedFields: ISaltedFields
+  ): Promise<boolean>;
+  publishPublicClaim(
+    issued: string,
+    verifyData: object,
+    opts?: { hashAlg: string; createHash: (data: string) => string }
+  ): Promise<string>;
+  publishPrivateClaim(
+    issued: string,
+    saltedFields: ISaltedFields,
+    opts?: { hashAlg: string; createHash: (data: string) => string }
+  ): Promise<string>;
 }
 
 export interface IClaimsIssuer extends IClaims {
@@ -26,6 +40,15 @@ export interface IClaimsIssuer extends IClaims {
 }
 
 export interface IClaimsVerifier extends IClaims {
-  verifyPublicProof(claimUrl: string): Promise<IPublicClaim>;
+  verifyPublicProof(
+    claimUrl: string,
+    {
+      holderDoc,
+      issuerDoc,
+    }?: {
+      holderDoc?: IDIDDocument;
+      issuerDoc?: IDIDDocument;
+    }
+  ): Promise<IPublicClaim>;
   verifyPrivateProof(proofToken: string): Promise<void>;
 }

--- a/packages/claims/src/interface.ts
+++ b/packages/claims/src/interface.ts
@@ -17,7 +17,7 @@ export interface IClaimsUser extends IClaims {
     issuer: string
   ): Promise<{ token: string; saltedFields: { [key: string]: string } }>;
   createProofClaim(claimUrl: string, saltedFields: IProofData): Promise<string>;
-  verifyPublicClaim(token: string, verifyData: object): Promise<boolean>;
+  verifyClaimContent(token: string, verifyData: object): Promise<boolean>;
   verifyPrivateClaim(
     privateToken: string,
     saltedFields: ISaltedFields

--- a/packages/claims/src/models/index.ts
+++ b/packages/claims/src/models/index.ts
@@ -48,5 +48,5 @@ export interface IClaims {
 
 export enum VerificationPurpose {
   Authentication = 'Authentication',
-  Verification = 'Verification',
+  Assertion = 'Assertion',
 }

--- a/packages/claims/src/models/index.ts
+++ b/packages/claims/src/models/index.ts
@@ -41,6 +41,12 @@ export interface IClaims {
   };
   jwt: IJWT;
   verify(
-    claimUrl: string, hashFns?: { [hashAlg: string]: (data: string) => string },
+    claimUrl: string,
+    hashFns?: { [hashAlg: string]: (data: string) => string }
   ): Promise<IPublicClaim | IPrivateClaim>;
+}
+
+export enum VerificationPurpose {
+  Authentication = 'Authentication',
+  Verification = 'Verification',
 }

--- a/packages/claims/src/utils/utils.ts
+++ b/packages/claims/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 
 export const hashes: { [hashAlg: string]: (data: string) => string } = {
-  SHA256: (data: string): string => crypto.createHash('sha256').update(data).digest('hex'),
+  SHA256: (data: string): string =>
+    crypto.createHash('sha256').update(data).digest('hex'),
 };

--- a/packages/claims/test/claimsFactory.test.ts
+++ b/packages/claims/test/claimsFactory.test.ts
@@ -5,12 +5,26 @@ import { Keys } from '@ew-did-registry/keys';
 import { EwSigner, Operator } from '@ew-did-registry/did-ethr-resolver';
 import { Methods } from '@ew-did-registry/did';
 import { DidStore } from '@ew-did-registry/did-ipfs-store';
-import { DIDDocumentFull } from '@ew-did-registry/did-document';
 import {
-  ClaimsFactory, IClaimsIssuer, IClaimsUser, IClaimsVerifier, IProofData,
+  DIDDocumentFull,
+  IDIDDocumentFull,
+} from '@ew-did-registry/did-document';
+import {
+  ClaimsFactory,
+  IClaimsIssuer,
+  IClaimsUser,
+  IClaimsVerifier,
+  IProofData,
 } from '../src';
-import { deployRegistry, shutDownIpfsDaemon, spawnIpfsDaemon } from '../../../tests';
-import { ProviderSettings, ProviderTypes } from '@ew-did-registry/did-resolver-interface';
+import {
+  deployRegistry,
+  shutDownIpfsDaemon,
+  spawnIpfsDaemon,
+} from '../../../tests';
+import {
+  ProviderSettings,
+  ProviderTypes,
+} from '@ew-did-registry/did-resolver-interface';
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -28,24 +42,45 @@ describe('[CLAIMS PACKAGE/FACTORY CLAIMS]', function () {
   const issuerKeys = new Keys();
   const issuerAddress = issuerKeys.getAddress();
   const issuerDid = `did:${Methods.Erc1056}:${issuerAddress}`;
-  const issuer = EwSigner.fromPrivateKey(issuerKeys.privateKey, providerSettings);
+  const issuer = EwSigner.fromPrivateKey(
+    issuerKeys.privateKey,
+    providerSettings
+  );
 
   const verifierKeys = new Keys();
   const verifierAddress = verifierKeys.getAddress();
   const verifierDid = `did:${Methods.Erc1056}:${verifierAddress}`;
-  const verifier = EwSigner.fromPrivateKey(verifierKeys.privateKey, providerSettings);
+  const verifier = EwSigner.fromPrivateKey(
+    verifierKeys.privateKey,
+    providerSettings
+  );
 
   let claimsUser: IClaimsUser;
   let claimsIssuer: IClaimsIssuer;
   let claimsVerifier: IClaimsVerifier;
 
+  let userDoc: IDIDDocumentFull;
+
   before(async () => {
-    const registry = await deployRegistry([userAddress, issuerAddress, verifierAddress]);
+    const registry = await deployRegistry([
+      userAddress,
+      issuerAddress,
+      verifierAddress,
+    ]);
     console.log(`registry: ${registry}`);
     const store = new DidStore(await spawnIpfsDaemon());
-    const userDoc = new DIDDocumentFull(userDid, new Operator(user, { address: registry }));
-    const issuerDoc = new DIDDocumentFull(issuerDid, new Operator(issuer, { address: registry }));
-    const verifierDoc = new DIDDocumentFull(verifierDid, new Operator(verifier, { address: registry }));
+    userDoc = new DIDDocumentFull(
+      userDid,
+      new Operator(user, { address: registry })
+    );
+    const issuerDoc = new DIDDocumentFull(
+      issuerDid,
+      new Operator(issuer, { address: registry })
+    );
+    const verifierDoc = new DIDDocumentFull(
+      verifierDid,
+      new Operator(verifier, { address: registry })
+    );
     await userDoc.create();
     await issuerDoc.create();
     await verifierDoc.create();
@@ -54,21 +89,21 @@ describe('[CLAIMS PACKAGE/FACTORY CLAIMS]', function () {
       userKeys,
       userDoc,
       store,
-      providerSettings,
+      providerSettings
     ).createClaimsUser();
 
     claimsIssuer = new ClaimsFactory(
       issuerKeys,
       issuerDoc,
       store,
-      providerSettings,
+      providerSettings
     ).createClaimsIssuer();
 
     claimsVerifier = new ClaimsFactory(
       verifierKeys,
       verifierDoc,
       store,
-      providerSettings,
+      providerSettings
     ).createClaimsVerifier();
   });
 
@@ -86,12 +121,18 @@ describe('[CLAIMS PACKAGE/FACTORY CLAIMS]', function () {
     // Issuer side
     const issuedToken = await claimsIssuer.issuePrivateClaim(privateToken);
     // Application/User side
-    const claimUrl = await claimsUser.publishPrivateClaim(issuedToken, saltedFields);
+    const claimUrl = await claimsUser.publishPrivateClaim(
+      issuedToken,
+      saltedFields
+    );
     const encryptedSaltedFields: IProofData = {
       private: { value: saltedFields.private, encrypted: true },
       public: { value: saltedFields.public, encrypted: false },
     };
-    const proofToken = await claimsUser.createProofClaim(claimUrl, encryptedSaltedFields);
+    const proofToken = await claimsUser.createProofClaim(
+      claimUrl,
+      encryptedSaltedFields
+    );
     // Verifier side
     try {
       await claimsVerifier.verifyPrivateProof(proofToken);
@@ -107,7 +148,10 @@ describe('[CLAIMS PACKAGE/FACTORY CLAIMS]', function () {
     // Issuer side
     const issuedToken = await claimsIssuer.issuePublicClaim(token);
     // Application/User side
-    const claimUrl = await claimsUser.publishPublicClaim(issuedToken, publicData);
+    const claimUrl = await claimsUser.publishPublicClaim(
+      issuedToken,
+      publicData
+    );
     // Verifier side
     return claimsVerifier.verifyPublicProof(claimUrl).should.be.fulfilled;
   });

--- a/packages/claims/test/claimsIssuer.test.ts
+++ b/packages/claims/test/claimsIssuer.test.ts
@@ -108,18 +108,4 @@ describe('[CLAIMS PACKAGE/ISSUER CLAIMS]', function () {
 
     return claimsUser.verify(url).should.be.fulfilled;
   });
-
-  it('claim issued by non-delegate should not be verified', async () => {
-    await userDoc.revokeDelegate(
-      PubKeyType.VerificationKey2018,
-      issuerDid,
-    );
-
-    let claim = await claimsUser.createPublicClaim(claimData);
-
-    claim = await claimsIssuer.issuePublicClaim(claim);
-
-    const url = await claimsUser.publishPublicClaim(claim, claimData);
-    expect(url).empty;
-  });
 });

--- a/packages/claims/test/proofVerifier.test.ts
+++ b/packages/claims/test/proofVerifier.test.ts
@@ -1,0 +1,165 @@
+import assert from 'assert';
+import { Wallet } from 'ethers';
+import ECKey from 'ec-key';
+import jsonwebtoken from 'jsonwebtoken';
+import { JWT } from '@ew-did-registry/jwt';
+import { ProofVerifier } from '../src/claimsVerifier/proofVerifier';
+import { mockDocument } from './testUtils/mockDidDocuments';
+import { Methods } from '@ew-did-registry/did';
+import { Keys } from '@ew-did-registry/keys';
+import {
+  IAuthentication,
+  IPublicKey,
+  PubKeyType,
+} from '@ew-did-registry/did-resolver-interface';
+
+const payload = {
+  claimType: 'user.roles.example1.apps.john.iam.ewc',
+  claimData: {
+    blockNumber: 42,
+    text: 'In EWC we trust',
+  },
+};
+const identity = Wallet.createRandom();
+const DID = `did:${Methods.Erc1056}:${identity.address}`;
+
+type delegateType = {
+  privKey: string;
+  publicKey: string;
+  address: string;
+};
+
+type ES256claimCreator = (signer: delegateType) => Promise<string>;
+type EIP191ClaimCreator = (signer?: Wallet | Keys) => Promise<string>;
+
+const createEIP191claim = async (signer?: Wallet | Keys) => {
+  if (!signer) {
+    signer = identity;
+  }
+  return new JWT(signer).sign({
+    ...payload,
+    iss: DID,
+  });
+};
+
+const createES256claim = async (signer: {
+  privKey: { toString: (arg0: string) => jsonwebtoken.Secret };
+}) =>
+  jsonwebtoken.sign(payload, signer.privKey.toString('pem'), {
+    algorithm: 'ES256',
+    noTimestamp: true,
+    issuer: DID,
+  });
+
+describe('AuthTokenVerifier', () => {
+  let verifier: ProofVerifier;
+  let claim: string;
+  let delegate: Wallet | Keys | delegateType;
+
+  describe('Authenticate as identity', () => {
+    it('should authenticate with empty document', async () => {
+      claim = await createEIP191claim(identity);
+      const document = mockDocument(identity, {
+        withOwnerKey: false,
+      });
+      verifier = new ProofVerifier(document);
+      const did = await verifier.authenticate(claim);
+
+      assert.strictEqual(did, document.id);
+    });
+
+    it('should not authenticate with other identity document', async () => {
+      claim = await createEIP191claim(identity);
+      const document = mockDocument(Wallet.createRandom(), {
+        withOwnerKey: false,
+      });
+      verifier = new ProofVerifier(document);
+      const did = await verifier.authenticate(claim);
+
+      assert.strictEqual(did, null);
+    });
+  });
+
+  describe('Authenticate as delegate', () => {
+    let createClaim: EIP191ClaimCreator | ES256claimCreator;
+
+    const delegateTests = (claimCreatorType: string) => {
+      it('sigAuth delegate should be authenticated', async () => {
+        if (delegate instanceof Wallet) {
+          const document = mockDocument(identity);
+          document.publicKey.push({
+            id: `did:${Methods.Erc1056}:${delegate.address}#${PubKeyType.SignatureAuthentication2018}`,
+            type: PubKeyType.SignatureAuthentication2018,
+            publicKeyHex: delegate.publicKey,
+          } as IPublicKey);
+          verifier = new ProofVerifier(document);
+          claim = await createClaim(delegate as (Wallet | Keys) & delegateType);
+          const did = await verifier.authenticate(claim);
+
+          assert.strictEqual(did, document.id);
+        }
+      });
+
+      it('authentication delegate should be authenticated', async () => {
+        delegate =
+          claimCreatorType === 'EIP191'
+            ? (delegate as delegateType)
+            : (delegate as Wallet);
+        const document = mockDocument(identity);
+        document.publicKey.push({
+          id: `did:${Methods.Erc1056}:${delegate.address}#${PubKeyType.VerificationKey2018}`,
+          type: PubKeyType.VerificationKey2018,
+          publicKeyHex: delegate.publicKey,
+        } as IPublicKey);
+        document.authentication.push({
+          publicKey: `did:${Methods.Erc1056}:${delegate.address}#delegate`,
+        } as IAuthentication);
+        verifier = new ProofVerifier(document);
+        claim = await createClaim(delegate as (Wallet | Keys) & delegateType);
+        const did = await verifier.authenticate(claim);
+
+        assert.strictEqual(did, document.id);
+      });
+
+      it('should reject authentication with mismatching DID doc', async () => {
+        const document = mockDocument(identity);
+        verifier = new ProofVerifier(document);
+        claim = await createClaim(delegate as (Wallet | Keys) & delegateType);
+        const did = await verifier.authenticate(claim);
+
+        assert.strictEqual(did, null);
+      });
+    };
+
+    describe('With ethers.Signer', () => {
+      before(() => {
+        delegate = Wallet.createRandom();
+        createClaim = createEIP191claim;
+      });
+      delegateTests('EIP191');
+    });
+
+    describe('With Keys signer', () => {
+      before(() => {
+        delegate = new Keys();
+        createClaim = createEIP191claim;
+      });
+
+      delegateTests('EIP191');
+    });
+
+    describe('With P256 signer', () => {
+      before(() => {
+        createClaim = createES256claim;
+        const privKey = ECKey.createECKey('prime256v1');
+        const publicKey = `0x${privKey.publicCodePoint.toString('hex')}`;
+        delegate = {
+          privKey,
+          publicKey,
+          address: publicKey,
+        };
+      });
+      delegateTests('ES256');
+    });
+  });
+});

--- a/packages/claims/test/proofVerifier.test.ts
+++ b/packages/claims/test/proofVerifier.test.ts
@@ -63,7 +63,7 @@ describe('AuthTokenVerifier', () => {
         withOwnerKey: false,
       });
       verifier = new ProofVerifier(document);
-      const did = await verifier.authenticate(claim);
+      const did = await verifier.verifyAuthenticationProof(claim);
 
       assert.strictEqual(did, document.id);
     });
@@ -74,7 +74,7 @@ describe('AuthTokenVerifier', () => {
         withOwnerKey: false,
       });
       verifier = new ProofVerifier(document);
-      const did = await verifier.authenticate(claim);
+      const did = await verifier.verifyAuthenticationProof(claim);
 
       assert.strictEqual(did, null);
     });
@@ -94,7 +94,7 @@ describe('AuthTokenVerifier', () => {
           } as IPublicKey);
           verifier = new ProofVerifier(document);
           claim = await createClaim(delegate as (Wallet | Keys) & delegateType);
-          const did = await verifier.authenticate(claim);
+          const did = await verifier.verifyAuthenticationProof(claim);
 
           assert.strictEqual(did, document.id);
         }
@@ -116,7 +116,7 @@ describe('AuthTokenVerifier', () => {
         } as IAuthentication);
         verifier = new ProofVerifier(document);
         claim = await createClaim(delegate as (Wallet | Keys) & delegateType);
-        const did = await verifier.authenticate(claim);
+        const did = await verifier.verifyAuthenticationProof(claim);
 
         assert.strictEqual(did, document.id);
       });
@@ -125,7 +125,7 @@ describe('AuthTokenVerifier', () => {
         const document = mockDocument(identity);
         verifier = new ProofVerifier(document);
         claim = await createClaim(delegate as (Wallet | Keys) & delegateType);
-        const did = await verifier.authenticate(claim);
+        const did = await verifier.verifyAssertionProof(claim);
 
         assert.strictEqual(did, null);
       });

--- a/packages/claims/test/testUtils/mockDidDocuments.ts
+++ b/packages/claims/test/testUtils/mockDidDocuments.ts
@@ -1,0 +1,39 @@
+import { Methods } from '@ew-did-registry/did';
+import {
+  IAuthentication,
+  IDIDDocument,
+  IPublicKey,
+  KeyTags,
+  PubKeyType,
+} from '@ew-did-registry/did-resolver-interface';
+import { Wallet, utils, BigNumber } from 'ethers';
+
+const { computePublicKey } = utils;
+
+export const mockDocument = (
+  identity: Wallet,
+  { withOwnerKey = true }: { withOwnerKey?: boolean } = {}
+): IDIDDocument => {
+  const did = `did:${Methods.Erc1056}:${identity.address}`;
+  const doc: IDIDDocument = {
+    '@context': '',
+    id: did,
+    publicKey: [] as IPublicKey[],
+    authentication: [] as IAuthentication[],
+    service: [],
+  } as IDIDDocument;
+  if (withOwnerKey) {
+    doc.authentication.push({
+      type: 'owner',
+      validity: BigNumber.from(47),
+      publicKey: `${did}#owner`,
+    });
+    doc.publicKey.push({
+      id: `${did}#${KeyTags.OWNER}`,
+      type: PubKeyType.VerificationKey2018,
+      controller: did,
+      publicKeyHex: computePublicKey(identity.publicKey, true),
+    } as IPublicKey);
+  }
+  return doc as IDIDDocument;
+};

--- a/packages/did-ethr-resolver/src/functions/functions.ts
+++ b/packages/did-ethr-resolver/src/functions/functions.ts
@@ -354,7 +354,9 @@ export const wrapDidDocument = (
     const pubKey = document.publicKey[key];
     const pubKeyValidity = pubKey.validity?.gt(now);
     if (pubKeyValidity) {
-      const { validity, block, ...pubKeyCopy } = { ...pubKey };
+      const pubKeyCopy: Omit<IPublicKey, 'validity' | 'block'> = pubKey;
+      delete pubKeyCopy.validity;
+      delete pubKeyCopy.block;
       didDocument.publicKey.push(pubKeyCopy as IPublicKey);
     }
   }
@@ -364,7 +366,9 @@ export const wrapDidDocument = (
     const authenticator = document.authentication[key];
     const authenticatorValidity = authenticator.validity?.gt(now);
     if (authenticatorValidity) {
-      const { validity, block, ...authenticatorCopy } = { ...authenticator };
+      const authenticatorCopy: Omit<IPublicKey, 'validity' | 'block'> = authenticator;
+      delete authenticatorCopy.validity;
+      delete authenticatorCopy.block;
       didDocument.authentication.push(authenticatorCopy as IAuthentication);
     }
   }
@@ -374,7 +378,9 @@ export const wrapDidDocument = (
     const serviceEndpoint = document.service[key];
     const serviceEndpointValidity = serviceEndpoint.validity?.gt(now);
     if (serviceEndpointValidity) {
-      const { validity, block, ...serviceEndpointCopy } = { ...serviceEndpoint };
+      const serviceEndpointCopy: Omit<IPublicKey, 'validity' | 'block'> = serviceEndpoint;
+      delete serviceEndpointCopy.validity;
+      delete serviceEndpointCopy.block;
       didDocument.service.push(serviceEndpointCopy as IServiceEndpoint);
     }
   }

--- a/packages/did-ethr-resolver/src/utils/crypto.ts
+++ b/packages/did-ethr-resolver/src/utils/crypto.ts
@@ -6,7 +6,7 @@ const {
   keccak256, hashMessage, arrayify, computePublicKey, recoverPublicKey, hexlify,
 } = utils;
 
-const didPattern = `^did:[a-z0-9]+?:?[a-z0-9]+?:(0x[A-Fa-f0-9]{40})$`;
+const didPattern = '^did:[a-z0-9]+?:?[a-z0-9]+?:(0x[A-Fa-f0-9]{40})$';
 export const compressedSecp256k1KeyLength = 66;
 
 export const walletPubKey = (

--- a/packages/did/src/utils/parser.ts
+++ b/packages/did/src/utils/parser.ts
@@ -13,7 +13,7 @@ export function getDIDMethod(did : string): string {
   if (!match) {
     throw new Error('Invalid DID');
   }
-  const [, method, ...param] = did.split(':');
+  const [, method] = did.split(':');
   return method;
 }
 
@@ -29,7 +29,7 @@ export function getDIDChain(did : string) : ChainInfo {
     throw new Error('Invalid DID');
   }
   if (did.split(':').length > 3) {
-    const [, , chain, ...param] = did.split(':');
+    const [, , chain] = did.split(':');
     return { foundChainInfo: true, chainInfo: chain };
   }
   return { foundChainInfo: false, chainInfo: undefined };

--- a/packages/jwt/src/index.ts
+++ b/packages/jwt/src/index.ts
@@ -1,3 +1,3 @@
-export { JWT } from './JWT256K';
+export { JWT } from './JWTEIP191';
 export * from './interface';
 export * from './types';

--- a/packages/jwt/test/jwt.test.ts
+++ b/packages/jwt/test/jwt.test.ts
@@ -4,7 +4,7 @@ import { Wallet } from 'ethers';
 import jsonwebtoken from 'jsonwebtoken';
 import ECKey from 'ec-key';
 import { Keys } from '@ew-did-registry/keys';
-import { JWT } from '../src/JWT256K';
+import { JWT } from '../src/JWTEIP191';
 import { Algorithms } from '../src/types';
 
 const { expect, should } = chai;


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description | Move authentication token verification from passport-did-auth to did-reg |
| Jira issue  | https://energyweb.atlassian.net/browse/PDA-18 |

### List of Features
- [x] `AuthTokenVerifier` moved to claims package to proof authentication and verification
- [x] authenticate issuers as part of claim verification

### List of bug-fixes
- Type of signer used to init JWT191 was determined by `instanceof` operator, which is not reliable, because prototype of the same type differs from version to version. Type checking will only include one property. For the `ethers.Signer` it will be `isSigner`, and for the `Keys` it is `privateKey` 
- replaced `no-shadow` rule of eslint by corresponding rule from @typescript-eslint, because of `error  'KeyType' is already declared in the upper scope` false error of eslint (https://github.com/typescript-eslint/tslint-to-eslint-config/issues/856) 
- stripping `validity` and `block` in `wrapDidDocument` is changed because of `unused variable` eslint error
- `Claims.verifySignature` is replaced by `ProofVerifier.verifyAssertionProof`

codacy checks failed, because some of its eslint rules differs from ours 