### PR TITLE
bug/SWTC-1459 missing revert data

### DIFF
--- a/packages/credentials-interface/package.json
+++ b/packages/credentials-interface/package.json
@@ -47,7 +47,7 @@
     "url": "git+https://github.com/energywebfoundation/ew-did-registry.git"
   },
   "dependencies": {
-    "@sphereon/pex": "^1.1.0",
+    "@sphereon/pex": "1.1.3",
     "@types/lodash": "^4.14.181",
     "joi": "^17.6.0",
     "lodash": "^4.17.21"

--- a/packages/proxyIdentity/src/errors/index.ts
+++ b/packages/proxyIdentity/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './only-owner-allowed';

--- a/packages/proxyIdentity/src/errors/only-owner-allowed.ts
+++ b/packages/proxyIdentity/src/errors/only-owner-allowed.ts
@@ -1,0 +1,5 @@
+export class OnlyOwnerAllowed extends Error {
+  constructor(identity: string, signer: string) {
+    super(`Signer ${signer} is not allowed to update DID identity ${identity}`);
+  }
+}


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description | In order to send transaction to offerable identity two conditons must be met. Signer should own offerable identity and offerable identity should own `did` being updated. First is checked in OfferableIdentity.sol. This PR adds second|

Also had to pin @sphereon/pex, because recent bugfix introduced breaking changes

