### PR TITLE
Make Credential.id required

### DIFF
--- a/packages/credentials-interface/src/credentials.types.ts
+++ b/packages/credentials-interface/src/credentials.types.ts
@@ -21,6 +21,7 @@ export enum CredentialType {
   EWFRole = 'EWFRole',
 }
 export interface Credential<T extends CredentialSubject> extends ICredential {
+  id: string;
   '@context': ICredentialContextType[];
   credentialSubject: T;
   credentialStatus?: StatusList2021Entry;


### PR DESCRIPTION
In `@sphereon/ssi-types` Credential.id is optional https://github.com/Sphereon-Opensource/ssi-sdk/blob/8f720df1ef84571ea2ef6eac1e3cd706849e53bc/packages/ssi-types/src/types/vc.ts#L21, but in all ours credential it is required

