### PR TITLE
fix(jwt): issue `iat` in seconds per RFC 7519

### DIFF
--- a/packages/jwt/src/JWTEIP191.ts
+++ b/packages/jwt/src/JWTEIP191.ts
@@ -66,7 +66,10 @@ export class JWT extends JwtBase implements IJWT {
       payload.sub = subject;
     }
     if (!noTimestamp) {
-      payload.iat = new Date().getTime();
+      // `iat` is a NumericDate: seconds since the epoch (RFC 7519, 4.1.6 / 2).
+      // `Date.now()` returns milliseconds, which is ~1000x too large and
+      // inconsistent with `exp` below (and with `jsonwebtoken`-issued tokens).
+      payload.iat = Math.floor(Date.now() / 1000);
     }
     if (expirationTimestamp) {
       if (expirationTimestamp < Date.now()) {

--- a/packages/jwt/test/jwt.test.ts
+++ b/packages/jwt/test/jwt.test.ts
@@ -104,3 +104,39 @@ describe('[JWT PACKAGE]', () => {
     });
   });
 });
+
+describe('[JWT iat/exp timestamps]', () => {
+  const signer = new JWT(new Keys());
+  // `sign` mutates its payload argument, so each test uses a fresh object
+  const freshPayload = () => ({ claim: 'test' });
+
+  it('`iat` should be a NumericDate in seconds, not milliseconds (RFC 7519)', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const token = await signer.sign(freshPayload());
+    const { iat } = signer.decode(token) as { iat: number };
+
+    expect(iat).to.be.a('number');
+    expect(Number.isInteger(iat)).to.equal(true);
+    // within a 5s window of "now" expressed in seconds; a milliseconds value
+    // would be ~1000x larger and fail this by many orders of magnitude
+    expect(Math.abs(iat - nowSeconds)).to.be.lessThan(5);
+  });
+
+  it('`iat` and `exp` should use the same unit', async () => {
+    const token = await signer.sign(freshPayload(), {
+      expirationTimestamp: Date.now() + 60_000,
+    });
+    const { iat, exp } = signer.decode(token) as { iat: number; exp: number };
+
+    expect(exp - iat).to.be.greaterThan(0);
+    // exp is ~60s after iat; if iat were in ms the gap would be hugely negative
+    expect(exp - iat).to.be.lessThan(120);
+  });
+
+  it('`iat` is omitted when noTimestamp is set', async () => {
+    const token = await signer.sign(freshPayload(), { noTimestamp: true });
+    const decoded = signer.decode(token) as { iat?: number };
+
+    expect(decoded.iat).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description | `JWT.sign` emitted the `iat` claim with `Date.now()` (**milliseconds**) — ~1000x the RFC 7519 NumericDate value, and inconsistent with `exp` (seconds) in the same token and with tokens issued via `jsonwebtoken` (e.g. the `ES256` branch of `iam-client-lib`'s `createDelegateProof`). Now emits seconds; adds regression tests. |
| Jira issue  | n/a — external contribution |

Closes #579

#### Type of request
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Features

- `iat` is now a NumericDate in **seconds** since the epoch (RFC 7519 §4.1.6 / §2), matching how `exp` is already emitted
- new `[JWT iat/exp timestamps]` block in `packages/jwt/test/jwt.test.ts`: `iat` is integer seconds ≈ now; `exp - iat` ≈ 60 (same unit); `iat` omitted under `noTimestamp`

### Notes

- One-line behaviour change in `packages/jwt/src/JWTEIP191.ts`; nothing in this repo or `iam-client-lib` reads `iat` as milliseconds (`grep -rn '\biat\b'` → only the type declaration and this assignment), so the change is safe.
- Verified against the patched build: `iat` is now seconds, `exp - iat === 60`, `noTimestamp` still omits `iat`, and the sign/verify round-trip is unaffected.
