### PR TITLE
fix(revocation): return real timestamps from getRevocations

### DIFF
--- a/packages/revocation/src/implementations/credential-revocation.ts
+++ b/packages/revocation/src/implementations/credential-revocation.ts
@@ -53,10 +53,9 @@ export class CredentialRevocation {
       credentialHash
     );
     const { 0: revokers, 1: timeStamps } = result;
-    const revokedTimeStamp = [];
-    for (let i = 0; i <= timeStamps.length; i++) {
-      revokedTimeStamp[i] = (Number(timeStamps[i]?._hex), 10).toString();
-    }
+    const revokedTimeStamp = timeStamps.map((timeStamp) =>
+      timeStamp.toString()
+    );
     return [revokers, revokedTimeStamp];
   }
 }

--- a/packages/revocation/test/revocation.test.ts
+++ b/packages/revocation/test/revocation.test.ts
@@ -60,4 +60,22 @@ describe('[CREDENTIAL REVOCATION]', function () {
     expect(result[0][0]).equal(revokerAddress);
     expect(result[0][1]).equal(revokerAddress);
   });
+
+  it('returns one real block timestamp per revocation', async () => {
+    expect(await revocationRegistry.revokeCredential(credential)).true;
+    expect(await revocationRegistry.revokeCredential(credential)).true;
+    const [revokers, timeStamps] = await revocationRegistry.getRevocations(
+      credential
+    );
+
+    // one timestamp per revoker, no trailing off-by-one element
+    expect(timeStamps.length).to.equal(revokers.length);
+    expect(timeStamps.length).to.equal(2);
+
+    timeStamps.forEach((ts) => {
+      expect(ts).to.match(/^[0-9]+$/);
+      // an actual unix timestamp, not the constant `10` the comma operator produced
+      expect(Number(ts)).to.be.greaterThan(1_600_000_000);
+    });
+  });
 });


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description | `CredentialRevocation.getRevocations()` returned `"10"` for every revocation timestamp and looped one element past the end of the array. |
| Jira issue  | n/a — external contribution |

Closes #583

#### Type of request
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Features

- `getRevocations()` now returns the real on-chain revocation timestamps
- `revocation.test.ts` gains a case asserting one real block timestamp per revocation (the existing cases only checked the revokers array)

### Detail

```ts
// before
const revokedTimeStamp = [];
for (let i = 0; i <= timeStamps.length; i++) {
  revokedTimeStamp[i] = (Number(timeStamps[i]?._hex), 10).toString();
}
```

`(Number(timeStamps[i]?._hex), 10)` is a comma expression: the parsed value is
evaluated and thrown away, and the expression is `10`, so every entry became
`"10"`. `i <= timeStamps.length` also iterated one past the last index.

```ts
// after
const revokedTimeStamp = timeStamps.map((timeStamp) => timeStamp.toString());
```

### Notes

- `packages/revocation/src/implementations/credential-revocation.ts` has a
  pre-existing `prettier --check` violation on the `import { ... } from '../../ethers'`
  line (unrelated to this change); left untouched to keep the diff focused.
